### PR TITLE
changed xyz to lat long

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1768,6 +1768,12 @@
         "@types/topojson-specification": "*"
       }
     },
+    "@types/proj4": {
+      "version": "2.5.0",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/@types/proj4/-/proj4-2.5.0.tgz",
+      "integrity": "sha1-QPHtHLnvZuRCq25X66MurcDwUBo=",
+      "dev": true
+    },
     "@types/selenium-webdriver": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.17.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/jasmine": "~2.8.8",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "~8.9.4",
+    "@types/proj4": "^2.5.0",
     "@types/socket.io-client": "^1.4.33",
     "codelyzer": "^5.0.1",
     "jasmine-core": "~2.99.1",

--- a/src/app/model/bodies/location-body.ts
+++ b/src/app/model/bodies/location-body.ts
@@ -1,7 +1,7 @@
+import Geometry from 'ol/geom/Geometry';
+
 export class LocationBody {
-  public x: number;
-  public y: number;
-  public z: number;
-  public epsgCode: number;
+  public coordinates: [number, number];
+  public type: Geometry;
   public baseObjectId: string;
 }

--- a/src/app/model/bodies/sensor-body.ts
+++ b/src/app/model/bodies/sensor-body.ts
@@ -1,15 +1,11 @@
+import { LocationBody } from './location-body';
+
 export interface ISensorSchema {
   sensorId: string;
   nodeId: string;
   ownerIds?: Array<string>;
   name?: string;
-  location: {
-      x: number,
-      y: number,
-      z: number,
-      epsgCode: number,
-      baseObjectId: string,
-  };
+  location: LocationBody;
   dataStreams?: Array<any>;
   aim?: string;
   description?: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "sourceMap": true,


### PR DESCRIPTION
The API now excepts and returns locations in GeoJSON format. Coordinates from API are therefore now transformed to RD before plotting, as that is what the GGC map requires. Similarly, DrawInteraction coordinates are now transformed to WGS84 before sending them to the back-end