### PR TITLE
Refresh tokens

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 # Author: Maarten Hoekstra (KKN), edited by Jeroen Grift for SensRNet
-FROM ubuntu:18.04
+FROM node:12
 
 ARG http_proxy="http://ssl-proxy.cs.kadaster.nl:8080"
 ARG https_proxy="http://ssl-proxy.cs.kadaster.nl:8080"
@@ -8,54 +8,22 @@ ARG HTTPS_PROXY=$http_proxy
 ARG no_proxy="localhost,127.0.0.1,kadaster.nl"
 ARG NO_PROXY=$no_proxy
 
-RUN apt-get update \
-    && apt-get install -y curl vim less gettext-base \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get install -y curl gettext-base \
-    && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
-    && apt-get install -y nodejs \
-    && mkdir /viewer \
-    && mkdir -p /var/appdata/run \
-    && mkdir -p /var/appdata/files
-
 WORKDIR /viewer
 
-# Copy of package.json and installation of NPM happens before the rest of the commands since it is a quite static and time consuming process. 
-COPY ./package.json /viewer/ 
+ADD VERSION .
 
-# N.B. this is a workaround to a scenario that has some risks! This project depends on generieke-geo-componenten,
-# generieke-geo-componenten depend on the deprecated openlayers library and the openlayers library depends on 
-# closure utils.
-# The situation is that the Kadaster internal network uses certinjection to monitor their employees. However the 
-# installation of closure-utils is not capable of handeling this properly. So to circumvent we need to disable 
-# TLS validation, which is pretty bad, and opens us up for a man in the middle attack. 
-RUN export NODE_TLS_REJECT_UNAUTHORIZED=0 \
-    && npm install -g @angular/cli \
-    && npm install closure-util \
-    && npm install rxjs
+COPY entrypoint.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
 
+COPY package*.json ./
 
 RUN npm config set registry https://dev-brm.cs.kadaster.nl/artifactory/api/npm/npm-registry/
 RUN npm install
 
-COPY ./e2e/ /viewer/e2e
-COPY ./src/ /viewer/src
-COPY ./angular.json /viewer/
-COPY ./tsconfig.json /viewer/ 
-COPY ./tsconfig.app.json /viewer/ 
-COPY ./tslint.json /viewer/
-COPY ./startup/*sh /var/appdata/run/
-COPY ./src/assets/layers.json /var/appdata/files/
-
-RUN chmod a+x /var/appdata/run/start-application.sh
-
-# Clean apt-get log
-RUN apt-get clean && \
-    rm -rf \
-    /tmp/* \
-    /var/lib/apt/lists/* \
-    /var/tmp
+COPY . .
 
 EXPOSE 4200
 
-CMD [ "/var/appdata/run/start-application.sh" ]
+ENTRYPOINT ["/viewer/entrypoint.sh"]
+
+CMD ["run"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec npx ng serve --disable-host-check --host 0.0.0.0 --configuration=production

--- a/package-lock.json
+++ b/package-lock.json
@@ -194,16 +194,29 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "9.1.9",
-      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/@angular-devkit/schematics/-/schematics-9.1.9.tgz",
-      "integrity": "sha1-E2nuWGy5H/6/Emc7uDnTGtXAA1c=",
+      "version": "9.1.10",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/@angular-devkit/schematics/-/schematics-9.1.10.tgz",
+      "integrity": "sha1-P5IGp29BvBun31ATc68wRt54L20=",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "9.1.9",
+        "@angular-devkit/core": "9.1.10",
         "ora": "4.0.3",
         "rxjs": "6.5.4"
       },
       "dependencies": {
+        "@angular-devkit/core": {
+          "version": "9.1.10",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/@angular-devkit/core/-/core-9.1.10.tgz",
+          "integrity": "sha1-Sy8dPJiJ2+YOOTblSgcM5niJPTY=",
+          "dev": true,
+          "requires": {
+            "ajv": "6.12.0",
+            "fast-json-stable-stringify": "2.1.0",
+            "magic-string": "0.25.7",
+            "rxjs": "6.5.4",
+            "source-map": "0.7.3"
+          }
+        },
         "rxjs": {
           "version": "6.5.4",
           "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/rxjs/-/rxjs-6.5.4.tgz",
@@ -221,16 +234,16 @@
       "integrity": "sha1-LHtuWE3wugiE0F8B+nq4bB/dHF4="
     },
     "@angular/cli": {
-      "version": "9.1.9",
-      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/@angular/cli/-/cli-9.1.9.tgz",
-      "integrity": "sha1-6crO18EHxlB1/htMQqRxKlrrmSw=",
+      "version": "9.1.10",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/@angular/cli/-/cli-9.1.10.tgz",
+      "integrity": "sha1-8lxFag/tI5/Yth8I8EPVeCVdZLs=",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.901.9",
-        "@angular-devkit/core": "9.1.9",
-        "@angular-devkit/schematics": "9.1.9",
-        "@schematics/angular": "9.1.9",
-        "@schematics/update": "0.901.9",
+        "@angular-devkit/architect": "0.901.10",
+        "@angular-devkit/core": "9.1.10",
+        "@angular-devkit/schematics": "9.1.10",
+        "@schematics/angular": "9.1.10",
+        "@schematics/update": "0.901.10",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.1",
         "debug": "4.1.1",
@@ -248,6 +261,29 @@
         "uuid": "7.0.2"
       },
       "dependencies": {
+        "@angular-devkit/architect": {
+          "version": "0.901.10",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/@angular-devkit/architect/-/architect-0.901.10.tgz",
+          "integrity": "sha1-RtiWEkvtkN9x4G0E1hDZ0dnE8kk=",
+          "dev": true,
+          "requires": {
+            "@angular-devkit/core": "9.1.10",
+            "rxjs": "6.5.4"
+          }
+        },
+        "@angular-devkit/core": {
+          "version": "9.1.10",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/@angular-devkit/core/-/core-9.1.10.tgz",
+          "integrity": "sha1-Sy8dPJiJ2+YOOTblSgcM5niJPTY=",
+          "dev": true,
+          "requires": {
+            "ajv": "6.12.0",
+            "fast-json-stable-stringify": "2.1.0",
+            "magic-string": "0.25.7",
+            "rxjs": "6.5.4",
+            "source-map": "0.7.3"
+          }
+        },
         "ansi-colors": {
           "version": "4.1.1",
           "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -261,6 +297,15 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
+          }
+        },
+        "rxjs": {
+          "version": "6.5.4",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/rxjs/-/rxjs-6.5.4.tgz",
+          "integrity": "sha1-4Hd/4NGEzseHLfFH8wNXLUFOIRw=",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
           }
         },
         "uuid": {
@@ -3028,23 +3073,47 @@
       }
     },
     "@schematics/angular": {
-      "version": "9.1.9",
-      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/@schematics/angular/-/angular-9.1.9.tgz",
-      "integrity": "sha1-358w3XtjhWEh+7mrXdpXtEOAKjM=",
+      "version": "9.1.10",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/@schematics/angular/-/angular-9.1.10.tgz",
+      "integrity": "sha1-wcGkRtZXZc7tl5IR4u6lAWIcv6k=",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "9.1.9",
-        "@angular-devkit/schematics": "9.1.9"
+        "@angular-devkit/core": "9.1.10",
+        "@angular-devkit/schematics": "9.1.10"
+      },
+      "dependencies": {
+        "@angular-devkit/core": {
+          "version": "9.1.10",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/@angular-devkit/core/-/core-9.1.10.tgz",
+          "integrity": "sha1-Sy8dPJiJ2+YOOTblSgcM5niJPTY=",
+          "dev": true,
+          "requires": {
+            "ajv": "6.12.0",
+            "fast-json-stable-stringify": "2.1.0",
+            "magic-string": "0.25.7",
+            "rxjs": "6.5.4",
+            "source-map": "0.7.3"
+          }
+        },
+        "rxjs": {
+          "version": "6.5.4",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/rxjs/-/rxjs-6.5.4.tgz",
+          "integrity": "sha1-4Hd/4NGEzseHLfFH8wNXLUFOIRw=",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        }
       }
     },
     "@schematics/update": {
-      "version": "0.901.9",
-      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/@schematics/update/-/update-0.901.9.tgz",
-      "integrity": "sha1-YoVhGRDr+LtAeER9K6MpMVle/NQ=",
+      "version": "0.901.10",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/@schematics/update/-/update-0.901.10.tgz",
+      "integrity": "sha1-7Yezj4VwrJ7c5tQc3qLq96dd7tg=",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "9.1.9",
-        "@angular-devkit/schematics": "9.1.9",
+        "@angular-devkit/core": "9.1.10",
+        "@angular-devkit/schematics": "9.1.10",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "1.3.5",
         "npm-package-arg": "^8.0.0",
@@ -3054,6 +3123,19 @@
         "semver-intersect": "1.4.0"
       },
       "dependencies": {
+        "@angular-devkit/core": {
+          "version": "9.1.10",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/@angular-devkit/core/-/core-9.1.10.tgz",
+          "integrity": "sha1-Sy8dPJiJ2+YOOTblSgcM5niJPTY=",
+          "dev": true,
+          "requires": {
+            "ajv": "6.12.0",
+            "fast-json-stable-stringify": "2.1.0",
+            "magic-string": "0.25.7",
+            "rxjs": "6.5.4",
+            "source-map": "0.7.3"
+          }
+        },
         "rxjs": {
           "version": "6.5.4",
           "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/rxjs/-/rxjs-6.5.4.tgz",
@@ -4264,7 +4346,7 @@
     },
     "builtins": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
@@ -5407,7 +5489,7 @@
     },
     "debuglog": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/debuglog/-/debuglog-1.0.1.tgz",
       "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "dev": true
     },
@@ -5608,7 +5690,7 @@
     },
     "dezalgo": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/dezalgo/-/dezalgo-1.0.3.tgz",
       "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "dev": true,
       "requires": {
@@ -5822,7 +5904,7 @@
     },
     "encoding": {
       "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
@@ -5943,7 +6025,7 @@
     },
     "err-code": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/err-code/-/err-code-1.1.2.tgz",
       "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
       "dev": true
     },
@@ -7222,7 +7304,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -7280,7 +7362,7 @@
     },
     "humanize-ms": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "requires": {
@@ -7502,34 +7584,11 @@
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
           "dev": true
         },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
-          "dev": true
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
         },
         "strip-ansi": {
           "version": "6.0.0",
@@ -8238,7 +8297,7 @@
     },
     "jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
@@ -8975,8 +9034,8 @@
     },
     "mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
       "dev": true
     },
     "mini-css-extract-plugin": {
@@ -9402,9 +9461,9 @@
       }
     },
     "npm-registry-fetch": {
-      "version": "4.0.4",
-      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/npm-registry-fetch/-/npm-registry-fetch-4.0.4.tgz",
-      "integrity": "sha1-LaHs8/Q9QZ2Wq/MTZkKRpGI9PqU=",
+      "version": "4.0.5",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/npm-registry-fetch/-/npm-registry-fetch-4.0.5.tgz",
+      "integrity": "sha1-y4fPfyW/sEjWw+4Z0RW+v5PqW/o=",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.4",
@@ -9778,7 +9837,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -10912,7 +10971,7 @@
     },
     "promise-retry": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/promise-retry/-/promise-retry-1.1.1.tgz",
       "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
       "dev": true,
       "requires": {
@@ -10922,7 +10981,7 @@
       "dependencies": {
         "retry": {
           "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/retry/-/retry-0.10.1.tgz",
           "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
           "dev": true
         }
@@ -13717,7 +13776,7 @@
     },
     "util-promisify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/util-promisify/-/util-promisify-2.1.0.tgz",
       "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
       "dev": true,
       "requires": {
@@ -13760,7 +13819,7 @@
     },
     "validate-npm-package-name": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.8",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --proxy-config src/proxy.conf.json",
     "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.901.9",
-    "@angular/cli": "~9.1.9",
+    "@angular/cli": "^9.1.10",
     "@angular/compiler-cli": "~9.1.11",
     "@angular/language-service": "~9.1.11",
     "@babel/compat-data": "~7.8.6",

--- a/src/app/helpers/error.interceptor.ts
+++ b/src/app/helpers/error.interceptor.ts
@@ -1,28 +1,91 @@
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { Observable, throwError } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { Observable, throwError, BehaviorSubject } from 'rxjs';
+import { catchError, filter, take, switchMap } from 'rxjs/operators';
 
 import { AuthenticationService } from '../services/authentication.service';
 
 @Injectable()
 export class ErrorInterceptor implements HttpInterceptor {
+  private refreshInProgress = false;
+  private refreshSubject: BehaviorSubject<any> = new BehaviorSubject<any>(
+    null
+  );
+
   constructor(
     private authenticationService: AuthenticationService,
     private router: Router,
   ) { }
 
-  public intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    return next.handle(request).pipe(catchError((err) => {
-      if (err.status === 401 && !this.router.routerState.snapshot.url.startsWith('/login')) {
-        // auto logout if 401 response returned from api
-        this.authenticationService.logout();
-        location.reload();
+  public intercept(request: HttpRequest<any>, next: HttpHandler): Observable<any> {
+    return next.handle(request).pipe(catchError((error) => {
+      if (request.url.includes('login') || request.url.includes('refresh')) {
+
+        if (request.url.includes('refresh')) {
+          this.authenticationService.logout();
+        }
+
+        return throwError(error);
       }
 
-      const error = err.error.error || err.statusText;
-      return throwError(error);
+      if (error.status !== 401) {
+        return throwError(error);
+      }
+
+      if (this.refreshInProgress) {
+        return this.refreshSubject.pipe(
+          filter(result => result !== null),
+          take(1),
+          switchMap(() => {
+            // refresh token
+            const currentOwner = this.authenticationService.currentOwnerValue;
+            if (currentOwner && currentOwner.access_token) {
+              request = request.clone({
+                setHeaders: {
+                  Authorization: `Bearer ${currentOwner.access_token}`,
+                },
+              });
+            }
+
+            return next.handle(request);
+          })
+        );
+      } else {
+        this.refreshInProgress = true;
+
+        this.refreshSubject.next(null);
+
+        return this.authenticationService
+          .refreshAccessToken()
+          .pipe(
+            switchMap((token: any) => {
+              this.refreshInProgress = false;
+
+              this.refreshSubject.next(token);
+
+              // add authorization header with jwt token if available
+              const currentOwner = this.authenticationService.currentOwnerValue;
+              if (currentOwner && currentOwner.access_token) {
+                request = request.clone({
+                  setHeaders: {
+                    Authorization: `Bearer ${currentOwner.access_token}`,
+                  },
+                });
+              }
+
+              return next.handle(request);
+            }),
+            catchError((authError: any) => {
+              this.refreshInProgress = false;
+
+              this.authenticationService.logout();
+              this.router.navigate(['/login']);
+
+              return throwError(authError);
+            })
+          );
+      }
     }));
   }
 }

--- a/src/app/helpers/jwt.interceptor.ts
+++ b/src/app/helpers/jwt.interceptor.ts
@@ -11,10 +11,10 @@ export class JwtInterceptor implements HttpInterceptor {
   public intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     // add authorization header with jwt token if available
     const currentOwner = this.authenticationService.currentOwnerValue;
-    if (currentOwner && currentOwner.accessToken) {
+    if (currentOwner && currentOwner.access_token) {
       request = request.clone({
         setHeaders: {
-          Authorization: `Bearer ${currentOwner.accessToken}`,
+          Authorization: `Bearer ${currentOwner.access_token}`,
         },
       });
     }

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -61,7 +61,7 @@ export class LoginComponent implements OnInit {
           this.router.navigate([this.returnUrl]);
         },
         (error) => {
-          this.alertService.error(error);
+          this.alertService.error(error.error.message);
           this.loading = false;
         });
   }

--- a/src/app/model/owner.ts
+++ b/src/app/model/owner.ts
@@ -4,9 +4,13 @@ export class Owner {
     public email: string,
     public password: string,
     public name: string,
-    public organization: string,
-    public phone: string,
+    public organisationName: string,
+    public contactEmail: string,
+    public contactPhone: string,
     public website: string,
-    public accessToken: string,
+    // tslint:disable-next-line: variable-name
+    public access_token: string,
+    // tslint:disable-next-line: variable-name
+    public expires_in: number,
   ) { }
 }

--- a/src/app/owner-update/owner-update.component.html
+++ b/src/app/owner-update/owner-update.component.html
@@ -9,6 +9,13 @@
         </div>
     </div>
     <div class="form-group">
+        <label for="organisationName">Organisation name</label> <span class="required">*</span>
+        <input type="text" formControlName="organisationName" class="form-control" [ngClass]="{ 'is-invalid': submitted && f.organisationName.errors }" />
+        <div *ngIf="submitted && f.organisationName.errors" class="invalid-feedback">
+            <div *ngIf="f.organisationName.errors.required">Organisation name is required</div>
+        </div>
+    </div>
+    <div class="form-group">
         <label for="contactEmail">Public e-mail</label> <span class="required">*</span>
         <input type="text" formControlName="contactEmail" class="form-control" [ngClass]="{ 'is-invalid': submitted && f.contactEmail.errors }" />
         <div *ngIf="submitted && f.contactEmail.errors" class="invalid-feedback">

--- a/src/app/owner-update/owner-update.component.ts
+++ b/src/app/owner-update/owner-update.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { AuthenticationService } from '../services/authentication.service';
 import { Owner } from '../model/owner';
@@ -8,7 +8,7 @@ import { Owner } from '../model/owner';
   templateUrl: './owner-update.component.html',
   styleUrls: ['./owner-update.component.sass']
 })
-export class OwnerUpdateComponent implements OnInit {
+export class OwnerUpdateComponent implements OnInit, OnChanges {
 
   @Input() public active = false;
   @Output() public closePane = new EventEmitter<void>();
@@ -20,10 +20,7 @@ export class OwnerUpdateComponent implements OnInit {
   constructor(
     private readonly formBuilder: FormBuilder,
     private readonly authenticationService: AuthenticationService,
-  ) {
-    this.authenticationService.currentOwner.subscribe((x) => this.currentOwner = x);
-    console.log(this.currentOwner);
-  }
+  ) {}
 
   get f() {
     return this.form.controls;
@@ -34,10 +31,38 @@ export class OwnerUpdateComponent implements OnInit {
 
     this.form = this.formBuilder.group({
       name: [this.currentOwner.name, Validators.required],
-      contactEmail: [this.currentOwner.email, [Validators.required, Validators.email]],
-      contactPhone: [this.currentOwner.phone, Validators.required],
+      organisationName: [this.currentOwner.organisationName, Validators.required],
+      contactPhone: [this.currentOwner.contactPhone, Validators.required],
+      contactEmail: [this.currentOwner.contactEmail, [Validators.required, Validators.email]],
       website: [this.currentOwner.website, [Validators.required, Validators.pattern(reg)]],
     });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.active) {
+      this.authenticationService.getOwner();
+      this.authenticationService.currentOwner.subscribe((owner: Owner) => {
+        this.currentOwner = owner;
+
+        if (!owner || !this.form) {
+          return;
+        }
+
+        this.form.setValue({
+          name: this.currentOwner.name,
+          organisationName: this.currentOwner.organisationName,
+          contactPhone: this.currentOwner.contactPhone,
+          contactEmail: this.currentOwner.contactEmail,
+          website: this.currentOwner.website,
+        });
+      });
+    }
+
+    if (changes.active.previousValue && !changes.active.currentValue) {
+      this.submitted = false;
+      this.success = false;
+      this.form.markAsPristine();
+    }
   }
 
   public async submit() {

--- a/src/app/register/register.component.html
+++ b/src/app/register/register.component.html
@@ -35,10 +35,10 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label for="organization">Organization name</label> <span class="required">*</span>
-                        <input type="text" formControlName="organization" class="form-control" [ngClass]="{ 'is-invalid': submitted && f.organization.errors }" />
-                        <div *ngIf="submitted && f.organization.errors" class="invalid-feedback">
-                            <div *ngIf="f.organization.errors.required">Organization is required</div>
+                        <label for="organisationName">Organisation name</label> <span class="required">*</span>
+                        <input type="text" formControlName="organisationName" class="form-control" [ngClass]="{ 'is-invalid': submitted && f.organisationName.errors }" />
+                        <div *ngIf="submitted && f.organisationName.errors" class="invalid-feedback">
+                            <div *ngIf="f.organisationName.errors.required">Organisation is required</div>
                         </div>
                     </div>
                     <div class="form-group">

--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -38,7 +38,7 @@ export class RegisterComponent implements OnInit {
 
       name: ['', Validators.required],
       role: ['', Validators.required],
-      organization: ['', Validators.required],
+      organisationName: ['', Validators.required],
       contactEmail: ['', [Validators.required, Validators.email]],
       contactPhone: ['', Validators.required],
       website: ['', [Validators.required, Validators.pattern(reg)]],
@@ -70,7 +70,7 @@ export class RegisterComponent implements OnInit {
           this.router.navigate(['/login']);
         },
         (error) => {
-          this.alertService.error(error);
+          this.alertService.error(error.error.error);
           this.loading = false;
         });
   }

--- a/src/app/services/authentication.service.ts
+++ b/src/app/services/authentication.service.ts
@@ -26,67 +26,81 @@ export class AuthenticationService {
     return this.http.post<any>(`${environment.apiUrl}/auth/login`, { username, password })
       .pipe(map((data) => {
 
-        const user: Owner = new Owner(
-          data.id,
-          data.email,
-          data.password,
-          data.name,
-          data.organization,
-          data.phone,
-          data.website,
-          data.access_token,
-        );
+        // store user details and jwt token in local storage to keep user logged in between page refreshes
+        localStorage.setItem('currentOwner', JSON.stringify(data));
+        this.currentOwnerSubject.next(data as Owner);
+
+        // TODO: In early test phases we conceptually combined users and owners. This leads to the creation of both on
+        // register, but only the user is returned. Therefore, an additional request is necessary for retrieving the
+        // saved owner information. Ideally this would be seperated.
+        this.getOwner();
+
+        return data;
+      }));
+  }
+
+  public refreshAccessToken(): Observable<Owner> {
+    return this.http.post<any>(`${environment.apiUrl}/auth/refresh`, null)
+      .pipe(map((data) => {
+
+        const user: Owner = { ...this.currentOwnerValue, ...data };
 
         // store user details and jwt token in local storage to keep user logged in between page refreshes
         localStorage.setItem('currentOwner', JSON.stringify(user));
         this.currentOwnerSubject.next(user);
 
-        // TODO: In early test phases we conceptually combined users and owners. This leads to the creation of both on
-        // register, but only the user is returned. Therefore, an additional request is necessary for retrieving the
-        // saved owner information. Ideally this would be seperated.
-        this.getOwner()
-        .subscribe((ownerData: Owner) => {
-          let owner: Owner = JSON.parse(localStorage.getItem('currentOwner'));
-
-          const partialUser = {
-            id: ownerData[0]._id,
-            email: ownerData[0].contactEmail,
-            name: ownerData[0].name,
-            phone: ownerData[0].contactPhone,
-            website: ownerData[0].website,
-          };
-
-          owner = {...owner, ...partialUser};
-
-          localStorage.setItem('currentOwner', JSON.stringify(owner));
-          this.currentOwnerSubject.next(owner);
-          return user;
-        });
+        return user;
       }));
   }
 
   // TODO: getOwner and updateOwner function are duplicated here from ownerService. This class should only concern the
   // authentication of a user. Therefore, these functions should return to ownerService.
-  public getOwner() {
-    return this.http.get<Owner>(`${environment.apiUrl}/Owner/`);
+  public getOwner(): void {
+    console.log('getOwner');
+    this.http.get<Owner>(`${environment.apiUrl}/Owner/`)
+      .subscribe((data) => {
+        let owner: Owner = JSON.parse(localStorage.getItem('currentOwner'));
+
+        const partialUser = {
+          id: data[0]._id,
+          name: data[0].name,
+          contactEmail: data[0].contactEmail,
+          contactPhone: data[0].contactPhone,
+          organisationName: data[0].organisationName,
+          website: data[0].website,
+        };
+
+        owner = { ...owner, ...partialUser };
+
+        console.log('got new owner', owner);
+
+        localStorage.setItem('currentOwner', JSON.stringify(owner));
+        this.currentOwnerSubject.next(owner);
+
+        return owner;
+      });
   }
 
-  public updateOwner(user: Owner) {
+  public updateOwner(user: Owner): Observable<Owner> {
     return this.http.put(`${environment.apiUrl}/Owner/`, user)
-    .pipe(map((data) => {
-      let owner: Owner = JSON.parse(localStorage.getItem('currentOwner'));
+      .pipe(map((data) => {
+        let owner: Owner = JSON.parse(localStorage.getItem('currentOwner'));
 
-      owner = {...owner, ...user};
+        owner = { ...owner, ...user };
 
-      localStorage.setItem('currentOwner', JSON.stringify(owner));
-      this.currentOwnerSubject.next(owner);
-      return user;
-    }));
+        localStorage.setItem('currentOwner', JSON.stringify(owner));
+        this.currentOwnerSubject.next(owner);
+        return user;
+      }));
   }
 
-  public logout() {
-    // remove user from local storage and set current user to null
+  public async logout() {
     localStorage.removeItem('currentOwner');
     this.currentOwnerSubject.next(null);
+    try {
+      await this.http.post<void>(`${environment.apiUrl}/auth/logout`, null).toPromise();
+    } catch (error) {
+      console.error('Something went wrong on logout', error);
+    }
   }
 }

--- a/src/app/viewer/viewer.component.ts
+++ b/src/app/viewer/viewer.component.ts
@@ -602,10 +602,8 @@ export class ViewerComponent implements OnInit {
   //   this.zoomToPoint(point);
   // }
 
-
-
-  public logout() {
-    this.authenticationService.logout();
+  public async logout() {
+    await this.authenticationService.logout();
     this.router.navigate(['/login']);
   }
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,7 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  apiUrl: 'http://localhost:3000/api',
+  apiUrl: 'api',
   production: false,
 };
 

--- a/src/proxy.conf.json
+++ b/src/proxy.conf.json
@@ -1,6 +1,6 @@
 {
-   "/api/*": {
-      "target": "http://localhost:3000",
+   "/api": {
+      "target": "http://localhost:3000/",
       "secure": false,
       "logLevel": "debug"
    }

--- a/startup/start-application.sh
+++ b/startup/start-application.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exec ng serve --disable-host-check --host 0.0.0.0 --configuration=production


### PR DESCRIPTION
- implement refresh tokens. When the server returns a 401, first try to refresh tokens. One such request is done, if more requests fail in the meantime, they subscribe to its result. When /refresh also fails, redirect user to login screen. Otherwise, retry the previous requests with the new access_token
- update docker file. Now base off of node, instead of ubuntu. This dramatically improves build speeds. Additionally, far fewer vulnerabilities are included this way.
- use proxy during local dev. This is due to the addition of cookies, I couldn't get them to work otherwise.