### PR TITLE
require user to pick sensor status

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,6 +24,7 @@ import { SensorThemeComponent } from './form-controls/sensor-theme/sensor-theme.
 import { SensorLocationComponent } from './form-controls/sensor-location/sensor-location.component';
 import { SensorTypeComponent } from './form-controls/sensor-type/sensor-type.component';
 import { OwnerUpdateComponent } from './owner-update/owner-update.component';
+import { SensorStatusComponent } from './form-controls/sensor-status/sensor-status.component';
 
 @NgModule({
   declarations: [
@@ -38,6 +39,7 @@ import { OwnerUpdateComponent } from './owner-update/owner-update.component';
     SensorLocationComponent,
     SensorTypeComponent,
     OwnerUpdateComponent,
+    SensorStatusComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/form-controls/sensor-status/sensor-status.component.html
+++ b/src/app/form-controls/sensor-status/sensor-status.component.html
@@ -1,0 +1,20 @@
+<div [formGroup]="form">
+    <label for="formControlRange">Sensor status</label>
+    <div class="form-group">
+        <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" value="true" formControlName="value">
+            <label class="form-check-label">
+                Active
+            </label>
+        </div>
+        <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" value="false" formControlName="value">
+            <label class="form-check-label">
+                Inactive
+            </label>
+        </div>
+    </div>
+    <div *ngIf="(f.value.dirty || f.value.touched || submitted) && f.value.errors" class="invalid-input">
+        <span *ngIf="f.value.errors.required">Status is required</span>
+    </div>
+</div>

--- a/src/app/form-controls/sensor-status/sensor-status.component.scss
+++ b/src/app/form-controls/sensor-status/sensor-status.component.scss
@@ -1,0 +1,3 @@
+label {
+  font-weight: normal;
+}

--- a/src/app/form-controls/sensor-status/sensor-status.component.spec.ts
+++ b/src/app/form-controls/sensor-status/sensor-status.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SensorStatusComponent } from './sensor-status.component';
+
+describe('SensorStatusComponent', () => {
+  let component: SensorStatusComponent;
+  let fixture: ComponentFixture<SensorStatusComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SensorStatusComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SensorStatusComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/form-controls/sensor-status/sensor-status.component.ts
+++ b/src/app/form-controls/sensor-status/sensor-status.component.ts
@@ -1,0 +1,94 @@
+import { Component, forwardRef, Input, OnDestroy } from '@angular/core';
+import { NG_VALUE_ACCESSOR, NG_VALIDATORS, FormGroup, FormBuilder, FormControl, Validators, ControlValueAccessor } from '@angular/forms';
+import { Subscription } from 'rxjs';
+
+export interface SensorThemeFormValues {
+  value: boolean;
+}
+
+@Component({
+  selector: 'app-sensor-status',
+  templateUrl: './sensor-status.component.html',
+  styleUrls: ['./sensor-status.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => SensorStatusComponent),
+      multi: true,
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => SensorStatusComponent),
+      multi: true,
+    },
+  ],
+})
+export class SensorStatusComponent implements ControlValueAccessor, OnDestroy {
+  public form: FormGroup;
+  public subscriptions: Subscription[] = [];
+
+  @Input()
+  public submitted: boolean;
+
+  get value(): SensorThemeFormValues {
+    return this.form.value;
+  }
+
+  set value(value: SensorThemeFormValues) {
+    if (!value) { return; }
+    this.form.setValue(value);
+    this.onChange(value);
+    this.onTouched();
+  }
+
+  constructor(
+    private formBuilder: FormBuilder,
+  ) {
+    this.form = this.formBuilder.group({
+      value: new FormControl(null, Validators.required),
+    });
+
+    this.subscriptions.push(
+      // any time the inner form changes update the parent of any change
+      this.form.valueChanges.subscribe((value) => {
+        this.onChange(value);
+        this.onTouched();
+      }),
+    );
+  }
+
+  public get f() {
+    return this.form.controls;
+  }
+
+  public ngOnDestroy() {
+    this.subscriptions.forEach((s) => s.unsubscribe());
+  }
+
+  public onChange: any = () => { };
+  public onTouched: any = () => { };
+
+  public registerOnChange(fn) {
+    this.onChange = fn;
+  }
+
+  public writeValue(value) {
+    if (value) {
+      this.value = value;
+    }
+
+    if (value === null) {
+      this.form.reset();
+    }
+  }
+
+  public registerOnTouched(fn) {
+    this.onTouched = fn;
+  }
+
+  // communicate the inner form validation to the parent form
+  public validate(_: FormControl) {
+    return this.form.valid ? null : { theme: { valid: false } };
+  }
+}
+

--- a/src/app/owner-update/owner-update.component.ts
+++ b/src/app/owner-update/owner-update.component.ts
@@ -6,7 +6,7 @@ import { Owner } from '../model/owner';
 @Component({
   selector: 'app-owner-update',
   templateUrl: './owner-update.component.html',
-  styleUrls: ['./owner-update.component.sass']
+  styleUrls: ['./owner-update.component.scss']
 })
 export class OwnerUpdateComponent implements OnInit, OnChanges {
 

--- a/src/app/sensor-register/sensor-register.component.html
+++ b/src/app/sensor-register/sensor-register.component.html
@@ -20,12 +20,7 @@
         <textarea class="form-control" type="text" formControlName="description"
             placeholder="Describe the sensor"></textarea>
     </div>
-    <div class="form-check">
-        <input class="form-check-input" type="checkbox" value="" formControlName="active">
-        <label class="form-check-label" for="active">
-            Sensor active
-        </label>
-    </div>
+    <app-sensor-status formControlName="active" [submitted]="submitted"></app-sensor-status>
     <hr>
     <div class="form-group">
         <label for="manufacturer"> Manufacturer <span class="required">*</span></label>

--- a/src/app/sensor-register/sensor-register.component.ts
+++ b/src/app/sensor-register/sensor-register.component.ts
@@ -65,7 +65,7 @@ export class SensorRegisterComponent implements OnInit, OnChanges {
       location: this.form.value.location || {},
       dataStreams: this.form.value.dataStreams || [],
 
-      active: this.form.value.active || false,
+      active: JSON.parse(this.form.value.active.value.toLowerCase()) || false, // cast strings (i.e. "true") to boolean
       aim: this.form.value.aim,
       description: this.form.value.description,
       documentationUrl: this.form.value.documentationUrl,

--- a/src/app/sensor-update/sensor-update.component.html
+++ b/src/app/sensor-update/sensor-update.component.html
@@ -20,12 +20,7 @@
         <textarea class="form-control" type="text" formControlName="description"
             placeholder="Describe the sensor"></textarea>
     </div>
-    <div class="form-check">
-        <input class="form-check-input" type="checkbox" value="" formControlName="active">
-        <label class="form-check-label" for="active">
-            Sensor active
-        </label>
-    </div>
+    <app-sensor-status formControlName="active"></app-sensor-status>
     <hr>
     <div class="form-group">
         <label for="manufacturer"> Manufacturer <span class="required">*</span></label>

--- a/src/app/sensor-update/sensor-update.component.ts
+++ b/src/app/sensor-update/sensor-update.component.ts
@@ -40,14 +40,14 @@ export class SensorUpdateComponent implements OnChanges {
   }
 
   public ngOnChanges(changes: SimpleChanges) {
-    if (changes.sensor) {
+    if (changes.sensor && changes.sensor.currentValue) {
       const selectedSensor = changes.sensor.currentValue ? changes.sensor.currentValue : {};
       this.form.setValue({
         name: selectedSensor.name || '',
         aim: selectedSensor.aim || '',
         description: selectedSensor.description || '',
         manufacturer: selectedSensor.manufacturer || '',
-        active: selectedSensor.active || false,
+        active: { value: selectedSensor.active.toString() || false },
         documentationUrl: selectedSensor.documentationUrl || '',
         location: {
           latitude: selectedSensor.location ? selectedSensor.location.coordinates[1] : null,
@@ -104,9 +104,10 @@ export class SensorUpdateComponent implements OnChanges {
     };
 
     try {
-      if (sensor.active === true && !this.sensor.active) {
+      const active: boolean = JSON.parse(sensor.active.value); // "true" -> true, case insensitive
+      if (active === true && !this.sensor.active) {
         await this.sensorService.activate(this.sensor._id);
-      } else if (sensor.active === false && this.sensor.active) {
+      } else if (active === false && this.sensor.active) {
         await this.sensorService.deactivate(this.sensor._id);
       }
     } catch (error) {


### PR DESCRIPTION
- user has to choose the sensor status, i.e. whether the sensor is active or inactive. Previously, we already had selected a default value. However, we want the user to consciously pick which one it is. Especially relevant for users who have to register multiple sensors and quickly want to fill out the form.
- refactored sensor status into its own component