### PR TITLE
make app white label

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Prerequisites:
 Commands:
 - Set registry: 'npm config set registry https://dev-brm.cs.kadaster.nl/artifactory/api/npm/npm-registry/'
 - Run: 'npm install'
-- Run: 'ng serve' (for a dev server. Navigate to "http://localhost:4200/". The app will automatically reload if you change any of the source files)
+- Run: 'npm run start' (for a dev server. Navigate to "http://localhost:4200/". The app will automatically reload if you change any of the source files)
 
 ## local development server with docker:
 
@@ -21,6 +21,17 @@ Prerequisites:
 Commands: 
 - Run: docker-compose build
 - Run: docker-compose up
+
+## Simulating different nodes
+During the development of the walking skeleton, we wanted to show how multiple environment can work toegether. For this purpose, the app has been setup as a white label app.
+For different 'costumers' we can define different environment variables and stylesheets.
+You can run the different scenarios as follows:
+Commands:
+- `ng serve --project=gemeente-a`
+- `ng serve --project=gemeente-b`
+- `ng serve --project=viewer`
+
+Building for deployment is then adding an additional flag `--configuration=production`.
 
 ## Find Us
 

--- a/angular.json
+++ b/angular.json
@@ -3,7 +3,7 @@
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
-    "viewer": {
+    "dev": {
       "projectType": "application",
       "schematics": {
         "@schematics/angular:component": {
@@ -17,7 +17,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "dist/viewer",
+            "outputPath": "dist/app",
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
@@ -35,57 +35,34 @@
             "styles": [
               "src/styles.scss"
             ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/app/scss/client.dev",
+                "node_modules/"
+              ]
+            },
             "scripts": [
               "./node_modules/jquery/dist/jquery.min.js",
               "./node_modules/bootstrap-select/dist/js/bootstrap-select.min.js",
               "./node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
             ]
-          },
-          "configurations": {
-            "production": {
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.prod.ts"
-                }
-              ],
-              "optimization": true,
-              "outputHashing": "all",
-              "sourceMap": false,
-              "extractCss": true,
-              "namedChunks": false,
-              "extractLicenses": true,
-              "vendorChunk": false,
-              "buildOptimizer": true,
-              "budgets": [
-                {
-                  "type": "initial",
-                  "maximumWarning": "2mb",
-                  "maximumError": "5mb"
-                },
-                {
-                  "type": "anyComponentStyle",
-                  "maximumWarning": "6kb",
-                  "maximumError": "10kb"
-                }
-              ]
-            }
           }
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "viewer:build"          },
+            "browserTarget": "dev:build"
+          },
           "configurations": {
             "production": {
-              "browserTarget": "viewer:build:production"
+              "browserTarget": "dev:build:production"
             }
           }
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "browserTarget": "viewer:build"
+            "browserTarget": "dev:build"
           }
         },
         "test": {
@@ -122,15 +99,301 @@
           "builder": "@angular-devkit/build-angular:protractor",
           "options": {
             "protractorConfig": "e2e/protractor.conf.js",
-            "devServerTarget": "viewer:serve"
+            "devServerTarget": "dev:serve"
           },
           "configurations": {
             "production": {
-              "devServerTarget": "viewer:serve:production"
+              "devServerTarget": "dev:serve:production"
             }
           }
         }
       }
-    }},
-  "defaultProject": "viewer"
+    },
+    "gemeente-a": {
+      "projectType": "application",
+      "schematics": {
+        "@schematics/angular:component": {
+          "style": "sass"
+        }
+      },
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/app",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.app.json",
+            "aot": true,
+            "assets": [
+              "src/favicon.ico",
+              "src/assets",
+              {
+                "glob": "**/*",
+                "input": "./node_modules/kadaster-huisstijl/dist/assets",
+                "output": "./assets/"
+              }
+            ],
+            "fileReplacements": [{
+              "replace": "src/environments/environment.ts",
+              "with": "src/environments/environment.gemeente-a.ts"
+            }],
+            "styles": [
+              "src/styles.scss"
+            ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/app/scss/client.gemeente-a",
+                "node_modules/"
+              ]
+            },
+            "scripts": [
+              "./node_modules/jquery/dist/jquery.min.js",
+              "./node_modules/bootstrap-select/dist/js/bootstrap-select.min.js",
+              "./node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
+            ]
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [{
+                "replace": "src/environments/environment.ts",
+                "with": "src/environments/environment.gemeente-a.prod.ts"
+              }],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "budgets": [{
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb",
+                  "maximumError": "10kb"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "gemeente-a:build"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "gemeente-a:build:production"
+            }
+          }
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "browserTarget": "gemeente-a:build"
+          }
+        }
+      }
+    },
+    "gemeente-b": {
+      "projectType": "application",
+      "schematics": {
+        "@schematics/angular:component": {
+          "style": "sass"
+        }
+      },
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/app",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.app.json",
+            "aot": true,
+            "assets": [
+              "src/favicon.ico",
+              "src/assets",
+              {
+                "glob": "**/*",
+                "input": "./node_modules/kadaster-huisstijl/dist/assets",
+                "output": "./assets/"
+              }
+            ],
+            "fileReplacements": [{
+              "replace": "src/environments/environment.ts",
+              "with": "src/environments/environment.gemeente-b.ts"
+            }],
+            "styles": [
+              "src/styles.scss"
+            ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/app/scss/client.gemeente-b",
+                "node_modules/"
+              ]
+            },
+            "scripts": [
+              "./node_modules/jquery/dist/jquery.min.js",
+              "./node_modules/bootstrap-select/dist/js/bootstrap-select.min.js",
+              "./node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
+            ]
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [{
+                "replace": "src/environments/environment.ts",
+                "with": "src/environments/environment.gemeente-b.prod.ts"
+              }],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "budgets": [{
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb",
+                  "maximumError": "10kb"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "gemeente-b:build"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "gemeente-b:build:production"
+            }
+          }
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "browserTarget": "gemeente-b:build"
+          }
+        }
+      }
+    },
+    "viewer": {
+      "projectType": "application",
+      "schematics": {
+        "@schematics/angular:component": {
+          "style": "sass"
+        }
+      },
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/app",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.app.json",
+            "aot": true,
+            "assets": [
+              "src/favicon.ico",
+              "src/assets",
+              {
+                "glob": "**/*",
+                "input": "./node_modules/kadaster-huisstijl/dist/assets",
+                "output": "./assets/"
+              }
+            ],
+            "fileReplacements": [{
+              "replace": "src/environments/environment.ts",
+              "with": "src/environments/environment.viewer.ts"
+            }],
+            "styles": [
+              "src/styles.scss"
+            ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/app/scss/client.viewer",
+                "node_modules/"
+              ]
+            },
+            "scripts": [
+              "./node_modules/jquery/dist/jquery.min.js",
+              "./node_modules/bootstrap-select/dist/js/bootstrap-select.min.js",
+              "./node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
+            ]
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [{
+                "replace": "src/environments/environment.ts",
+                "with": "src/environments/environment.viewer.prod.ts"
+              }],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "budgets": [{
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb",
+                  "maximumError": "10kb"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "viewer:build"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "viewer:build:production"
+            }
+          }
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "browserTarget": "viewer:build"
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "dev"
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec npx ng serve --disable-host-check --host 0.0.0.0 --configuration=production
+exec npx ng serve --disable-host-check --host 0.0.0.0 --project=$PROJECT --configuration=$CONFIGURATION

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,8 @@ import { Router } from '@angular/router';
 
 import { Owner } from './model/owner';
 import { AuthenticationService } from './services/authentication.service';
+import { Title } from '@angular/platform-browser';
+import { environment } from '../environments/environment';
 
 @Component({ selector: 'app-root', templateUrl: 'app.component.html' })
 export class AppComponent {
@@ -11,8 +13,14 @@ export class AppComponent {
   constructor(
     private router: Router,
     private authenticationService: AuthenticationService,
+    private titleService: Title,
   ) {
     this.authenticationService.currentOwner.subscribe((x) => this.currentOwner = x);
+    this.setTitle(environment.clientName);
+  }
+
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
   }
 
   public logout() {

--- a/src/app/helpers/auth.guard.ts
+++ b/src/app/helpers/auth.guard.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
 
 import { AuthenticationService } from '../services/authentication.service';
+import { environment } from '../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class AuthGuard implements CanActivate {
@@ -11,6 +12,11 @@ export class AuthGuard implements CanActivate {
   ) { }
 
   public canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    // Environment is readonly, no login available. Skip
+    if (environment.isReadonly) {
+      return true;
+    }
+
     const currentOwner = this.authenticationService.currentOwnerValue;
     if (currentOwner) {
       // authorised so return true

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -3,6 +3,7 @@
         <div class="row">
             <div class="col-sm-6 offset-sm-3">
                 <h1>Welcome to SensRNet</h1>
+                <h2>{{ environment.clientName }} </h2>
                 <div class="welcome-image">
                     <img src="assets\SensRNet-logo.png" class="image">
                 </div>

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -5,6 +5,7 @@ import { first } from 'rxjs/operators';
 
 import { AlertService } from '../services/alert.service';
 import { AuthenticationService } from '../services/authentication.service';
+import { environment } from '../../environments/environment';
 
 @Component({
   styleUrls: ['./login.component.scss'],
@@ -16,6 +17,8 @@ export class LoginComponent implements OnInit {
   public submitted = false;
   public returnUrl: string;
 
+  public environment = environment;
+
   constructor(
     private formBuilder: FormBuilder,
     private route: ActivatedRoute,
@@ -25,6 +28,11 @@ export class LoginComponent implements OnInit {
   ) {
     // redirect to home if already logged in
     if (this.authenticationService.currentOwnerValue) {
+      this.router.navigate(['/']);
+    }
+
+    // redirect if app is in readonly mode
+    if (this.environment.isReadonly) {
       this.router.navigate(['/']);
     }
   }

--- a/src/app/owner-update/owner-update.component.ts
+++ b/src/app/owner-update/owner-update.component.ts
@@ -30,11 +30,11 @@ export class OwnerUpdateComponent implements OnInit, OnChanges {
     const reg = '(https?://)?([\\da-z.-]+)\\.([a-z.]{2,6})[/\\w .-]*/?';
 
     this.form = this.formBuilder.group({
-      name: [this.currentOwner.name, Validators.required],
-      organisationName: [this.currentOwner.organisationName, Validators.required],
-      contactPhone: [this.currentOwner.contactPhone, Validators.required],
-      contactEmail: [this.currentOwner.contactEmail, [Validators.required, Validators.email]],
-      website: [this.currentOwner.website, [Validators.required, Validators.pattern(reg)]],
+      name: [this.currentOwner ? this.currentOwner.name : '', Validators.required],
+      organisationName: [this.currentOwner ? this.currentOwner.organisationName : '', Validators.required],
+      contactPhone: [this.currentOwner ? this.currentOwner.contactPhone : '', Validators.required],
+      contactEmail: [this.currentOwner ? this.currentOwner.contactEmail : '', [Validators.required, Validators.email]],
+      website: [this.currentOwner ? this.currentOwner.website : '', [Validators.required, Validators.pattern(reg)]],
     });
   }
 

--- a/src/app/scss/client.dev/_theme.scss
+++ b/src/app/scss/client.dev/_theme.scss
@@ -1,0 +1,3 @@
+// color indicating local development
+$theme-color-primary: lightgrey;
+$theme-color-text: black;

--- a/src/app/scss/client.gemeente-a/_theme.scss
+++ b/src/app/scss/client.gemeente-a/_theme.scss
@@ -1,0 +1,3 @@
+// color of municipality of Apeldoorn
+$theme-color-primary: rgb(0, 120, 54);
+$theme-color-text: rgb(255, 255, 255);

--- a/src/app/scss/client.gemeente-b/_theme.scss
+++ b/src/app/scss/client.gemeente-b/_theme.scss
@@ -1,0 +1,3 @@
+// color of municipality of Eindhoven
+$theme-color-primary: rgb(227, 37, 39);
+$theme-color-text: rgb(246, 247, 248);

--- a/src/app/scss/client.viewer/_theme.scss
+++ b/src/app/scss/client.viewer/_theme.scss
@@ -1,0 +1,3 @@
+// primary color of Kadaster
+$theme-color-primary: rgb(0, 130, 150);
+$theme-color-text: rgb(255, 255, 255);

--- a/src/app/viewer/viewer.component.html
+++ b/src/app/viewer/viewer.component.html
@@ -2,7 +2,7 @@
     <div class="row">
         <ul class="col-lg-12 nav nav-pills navbar">
             <span class="header">SensRNet Registration App</span>
-            <li class="dropdown">
+            <li *ngIf="!environment.isReadonly" class="dropdown">
                 <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
                     aria-expanded="false">Owner</a>
                 <ul class="dropdown-menu">
@@ -10,7 +10,7 @@
                     <li><a role="button" (click)="togglePane('OwnerUpdate')">Update owner</a></li>
                 </ul>
             </li>
-            <li class="dropdown">
+            <li *ngIf="!environment.isReadonly" class="dropdown">
                 <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
                     aria-expanded="false">Sensor</a>
                 <ul class="dropdown-menu">
@@ -19,7 +19,7 @@
                     <li><a role="button" (click)="togglePane('SensorUpdate')">Update sensor</a></li>
                 </ul>
             </li>
-            <li class="dropdown logout">
+            <li *ngIf="!environment.isReadonly" class="dropdown logout">
                 <a class="dropdown-toggle" (click)="logout()" role="button" aria-haspopup="true"
                     aria-expanded="false">Logout</a>
             </li>
@@ -30,20 +30,20 @@
         </div>
     </div>
 
-    <div class="row">
+    <div *ngIf="!environment.isReadonly" class="row">
         <div [ngbCollapse]="!paneOwnerUpdateActive" class="app-form">
             <app-owner-update [active]="paneOwnerUpdateActive" (closePane)="toggleOwnerUpdatePane(false)">
             </app-owner-update>
         </div>
     </div>
 
-    <div class="row">
+    <div *ngIf="!environment.isReadonly" class="row">
         <div [ngbCollapse]="!paneSensorRegisterActive" class="app-form">
             <app-sensor-register [active]="paneSensorRegisterActive"></app-sensor-register>
         </div>
     </div>
 
-    <div class="row">
+    <div *ngIf="!environment.isReadonly" class="row">
         <div [ngbCollapse]="!paneSensorUpdateActive" class="app-form">
             <app-sensor-update [sensor]="selectedSensor" [active]="paneSensorUpdateActive"
                 (closePane)="toggleSensorUpdatePane(false)"></app-sensor-update>

--- a/src/app/viewer/viewer.component.scss
+++ b/src/app/viewer/viewer.component.scss
@@ -1,9 +1,11 @@
+@import "../../styles";
+
 .navbar {
   position: absolute;
   z-index: 20;
   width: 100%;
   height: 50px;
-  background-color: rgba(19, 65, 115, 0.8);
+  background-color: $theme-color-primary;
   box-shadow: 0 10px 10px -5px grey;
   padding: 0px 0px 0px 0px;
   border-radius: 0px;
@@ -21,6 +23,10 @@
     margin-left: 15px;
     margin-right: 15px;
     color: white;
+  }
+
+  a {
+    color: $theme-color-text;
   }
 
   .logout {

--- a/src/environments/environment.gemeente-a.prod.ts
+++ b/src/environments/environment.gemeente-a.prod.ts
@@ -1,0 +1,6 @@
+export const environment = {
+  apiUrl: 'http://gemeente-a-sensrnet.westeurope.cloudapp.azure.com/api',
+  clientName: 'Gemeente A',
+  isReadonly: false,
+  production: true,
+};

--- a/src/environments/environment.gemeente-a.ts
+++ b/src/environments/environment.gemeente-a.ts
@@ -1,0 +1,6 @@
+export const environment = {
+  apiUrl: 'http://gemeente-a-sensrnet-test.westeurope.cloudapp.azure.com/api',
+  clientName: 'Gemeente A',
+  isReadonly: false,
+  production: false,
+};

--- a/src/environments/environment.gemeente-b.prod.ts
+++ b/src/environments/environment.gemeente-b.prod.ts
@@ -1,0 +1,6 @@
+export const environment = {
+  apiUrl: 'http://gemeente-b-sensrnet.westeurope.cloudapp.azure.com/api',
+  clientName: 'Gemeente B',
+  isReadonly: false,
+  production: true,
+};

--- a/src/environments/environment.gemeente-b.ts
+++ b/src/environments/environment.gemeente-b.ts
@@ -1,0 +1,6 @@
+export const environment = {
+  apiUrl: 'http://gemeente-b-sensrnet-test.westeurope.cloudapp.azure.com/api',
+  clientName: 'Gemeente B',
+  isReadonly: false,
+  production: false,
+};

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,0 @@
-export const environment = {
-  apiUrl: 'http://sensrnet-test.westeurope.cloudapp.azure.com/api',
-  production: true,
-};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,6 +4,8 @@
 
 export const environment = {
   apiUrl: 'api',
+  clientName: 'Local',
+  isReadonly: false,
   production: false,
 };
 

--- a/src/environments/environment.viewer.prod.ts
+++ b/src/environments/environment.viewer.prod.ts
@@ -1,0 +1,6 @@
+export const environment = {
+  apiUrl: 'http://viewer-sensrnet.westeurope.cloudapp.azure.com/api',
+  clientName: 'Viewer',
+  isReadonly: true,
+  production: true,
+};

--- a/src/environments/environment.viewer.ts
+++ b/src/environments/environment.viewer.ts
@@ -1,0 +1,6 @@
+export const environment = {
+  apiUrl: 'http://viewer-sensrnet-test.westeurope.cloudapp.azure.com/api',
+  clientName: 'Viewer',
+  isReadonly: true,
+  production: false,
+};

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,13 +2,16 @@
 $body-bg: white;
 $font-size-base: 1.25rem;
 
+// Load client specific theme
+@import 'theme';
+
 // Bootstrap and its default variables
-@import "../node_modules/kadaster-huisstijl/dist/css/kadaster-huisstijl.css";
-@import "../node_modules/bootstrap/scss/bootstrap.scss";
-$fa-font-path: "../node_modules/font-awesome/fonts";
-@import "../node_modules/font-awesome/scss/font-awesome.scss";
-@import "../node_modules/bootstrap-select/dist/css/bootstrap-select.min.css";
-@import "../node_modules/ol/ol.css";
+@import "kadaster-huisstijl/dist/css/kadaster-huisstijl.css";
+@import "bootstrap/scss/bootstrap.scss";
+$fa-font-path: "font-awesome/fonts";
+@import "font-awesome/scss/font-awesome.scss";
+@import "bootstrap-select/dist/css/bootstrap-select.min.css";
+@import "ol/ol.css";
 
 .ol-overlaycontainer-stopevent .ol-zoom {
   top: auto;


### PR DESCRIPTION
- added multiple environments, two for each 'client', a test environment and prod environment. In reality, we'll probably only use one environment per client, but it is nice to have the option.
- added multiple stylesheets, for making extra clear the distinction between clients.
- made webpage title configurable, same reason as before
- in isReadonly environments, disable login and management features
- updated README.md