### PR TITLE
update k8s config files

### DIFF
--- a/deployment/base/deployment.yaml
+++ b/deployment/base/deployment.yaml
@@ -1,25 +1,35 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    app: registry-frontend
   name: registry-frontend
 spec:
   replicas: 1
-  selector:
-    matchLabels:
-      app: registry-frontend
-  strategy: {}
   template:
-    metadata:
-      labels:
-        app: registry-frontend
     spec:
       containers:
       - image: sensrnetregistry.azurecr.io/sensrnet/registry-frontend:latest
         name: registry-frontend
         ports:
-        - containerPort: 8080
-        resources: {}
-      restartPolicy: Always
-status: {}
+        - name: http
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /nginx-health
+            port: http
+          initialDelaySeconds: 3
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /nginx-health
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        args:
+          - -health-status=true
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "200m"
+            memory: "256Mi"

--- a/deployment/base/ingress.yaml
+++ b/deployment/base/ingress.yaml
@@ -1,9 +1,9 @@
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
+  name: registry-frontend-ingress
   annotations:
     kubernetes.io/ingress.class: traefik
-  name: registry-frontend-ingress
 spec:
   entryPoints:
   - http

--- a/deployment/base/kustomization.yaml
+++ b/deployment/base/kustomization.yaml
@@ -1,7 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: sensrnet-frontend
+namespace: registry-frontend
+
+commonLabels:
+  app.kubernetes.io/name: sensrnet
+  app.kubernetes.io/component: registry-frontend
 
 resources:
   - namespace.yaml

--- a/deployment/base/namespace.yaml
+++ b/deployment/base/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: sensrnet-frontend
+  name: registry-frontend

--- a/deployment/base/service.yaml
+++ b/deployment/base/service.yaml
@@ -1,13 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app: registry-frontend
   name: registry-frontend
 spec:
   ports:
   - port: 80
     protocol: TCP
-    targetPort: 8080
-  selector:
-    app: registry-frontend
+    targetPort: http

--- a/deployment/overlays/local/deployment.yaml
+++ b/deployment/overlays/local/deployment.yaml
@@ -3,9 +3,6 @@ kind: Deployment
 metadata:
   name: registry-frontend
 spec:
-  selector:
-    matchLabels:
-      app: registry-frontend
   template:
     spec:
       containers:


### PR DESCRIPTION
Added:
- health checks (liveness + readiness)
- resource limits
- renamed namespace from `sensrnet-frontend` to `registry-frontend`, although this might change again to something like `test` and `prod`
- added commonLabels for resource identification
- use named ports

Links to kadaster-labs/sensrnet-ops#12