### PR TITLE
update dependencies in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4191,6 +4191,16 @@
       "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w=",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "blob": {
       "version": "0.0.5",
       "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/blob/-/blob-0.0.5.tgz",
@@ -6025,24 +6035,24 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha1-2jfOvTHnmhNn6UG1ku0fvr1Yq7s=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+          "version": "4.12.0",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og=",
           "dev": true
         }
       }
@@ -6100,29 +6110,29 @@
       }
     },
     "engine.io": {
-      "version": "3.4.2",
-      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/engine.io/-/engine.io-3.4.2.tgz",
-      "integrity": "sha1-j8hO4AOI4+IoZF4KfT367tW9Eiw=",
+      "version": "3.5.0",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/engine.io/-/engine.io-3.5.0.tgz",
+      "integrity": "sha1-nWuYXIo5sf6HzZHrAU3gVSJZghs=",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
-        "cookie": "0.3.1",
+        "cookie": "~0.4.1",
         "debug": "~4.1.0",
         "engine.io-parser": "~2.2.0",
-        "ws": "^7.1.2"
+        "ws": "~7.4.2"
       },
       "dependencies": {
         "cookie": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+          "version": "0.4.1",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha1-r9cT/ibr0hupXOth+agRblClN9E=",
           "dev": true
         },
         "ws": {
-          "version": "7.3.0",
-          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/ws/-/ws-7.3.0.tgz",
-          "integrity": "sha1-Sy9/IZs9Nze8Gi+/FF2CW5TTj/0=",
+          "version": "7.4.4",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/ws/-/ws-7.4.4.tgz",
+          "integrity": "sha1-ODvJdCyyAikskHfOq29gR7F/LVk=",
           "dev": true
         }
       }
@@ -6168,16 +6178,24 @@
       }
     },
     "engine.io-parser": {
-      "version": "2.2.0",
-      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
-      "integrity": "sha1-MSxIlPV9UqArQgho2ntcHISvgO0=",
+      "version": "2.2.1",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
+      "integrity": "sha1-V85WEdk3DulPmWQbWJ+UyX5PXac=",
       "dev": true,
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "~0.0.7",
-        "base64-arraybuffer": "0.1.5",
+        "base64-arraybuffer": "0.1.4",
         "blob": "0.0.5",
         "has-binary2": "~1.0.2"
+      },
+      "dependencies": {
+        "base64-arraybuffer": {
+          "version": "0.1.4",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+          "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
+          "dev": true
+        }
       }
     },
     "enhanced-resolve": {
@@ -7073,6 +7091,13 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/fill-range/-/fill-range-7.0.1.tgz",
@@ -7742,8 +7767,8 @@
     },
     "hash.js": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -7763,7 +7788,7 @@
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
@@ -8190,8 +8215,7 @@
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "resolved": "",
       "dev": true
     },
     "ink-docstrap": {
@@ -9760,7 +9784,7 @@
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
@@ -9917,6 +9941,13 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha1-9TdkAGlRaPTMaUrJOT0MlYXu6hk=",
+      "dev": true,
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -9966,11 +9997,6 @@
       "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
-    },
-    "ngx-tree-select": {
-      "version": "0.15.0",
-      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/ngx-tree-select/-/ngx-tree-select-0.15.0.tgz",
-      "integrity": "sha1-OhJ/ij0x8nRMwfoWi6jugNGucpA="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -13236,17 +13262,120 @@
       }
     },
     "socket.io": {
-      "version": "2.3.0",
-      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/socket.io/-/socket.io-2.3.0.tgz",
-      "integrity": "sha1-zXYu1qT67KWbwfPiQ8CWkxHrc/s=",
+      "version": "2.4.1",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/socket.io/-/socket.io-2.4.1.tgz",
+      "integrity": "sha1-la2GHJpSNp1/Gmis8NShsW2kUdI=",
       "dev": true,
       "requires": {
         "debug": "~4.1.0",
-        "engine.io": "~3.4.0",
+        "engine.io": "~3.5.0",
         "has-binary2": "~1.0.2",
         "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "2.3.0",
+        "socket.io-client": "2.4.0",
         "socket.io-parser": "~3.4.0"
+      },
+      "dependencies": {
+        "engine.io-client": {
+          "version": "3.5.1",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/engine.io-client/-/engine.io-client-3.5.1.tgz",
+          "integrity": "sha1-tQBFijnAzRl6kh4OdZchp0bQvbk=",
+          "dev": true,
+          "requires": {
+            "component-emitter": "~1.3.0",
+            "component-inherit": "0.0.3",
+            "debug": "~3.1.0",
+            "engine.io-parser": "~2.2.0",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "parseqs": "0.0.6",
+            "parseuri": "0.0.6",
+            "ws": "~7.4.2",
+            "xmlhttprequest-ssl": "~1.5.4",
+            "yeast": "0.1.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "parseqs": {
+          "version": "0.0.6",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/parseqs/-/parseqs-0.0.6.tgz",
+          "integrity": "sha1-jku1oZ0c3IRKCKyXTTTic6+mcNU=",
+          "dev": true
+        },
+        "parseuri": {
+          "version": "0.0.6",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/parseuri/-/parseuri-0.0.6.tgz",
+          "integrity": "sha1-4Ulugp46wv9H85pN0ESzKCPEolo=",
+          "dev": true
+        },
+        "socket.io-client": {
+          "version": "2.4.0",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/socket.io-client/-/socket.io-client-2.4.0.tgz",
+          "integrity": "sha1-qvtdWUo8VaNDVVYvyK6iLtkRmjU=",
+          "dev": true,
+          "requires": {
+            "backo2": "1.0.2",
+            "component-bind": "1.0.0",
+            "component-emitter": "~1.3.0",
+            "debug": "~3.1.0",
+            "engine.io-client": "~3.5.0",
+            "has-binary2": "~1.0.2",
+            "indexof": "0.0.1",
+            "parseqs": "0.0.6",
+            "parseuri": "0.0.6",
+            "socket.io-parser": "~3.3.0",
+            "to-array": "0.1.4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "socket.io-parser": {
+              "version": "3.3.2",
+              "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
+              "integrity": "sha1-74cgCdCtz3BPL76DAZGhR1KtULY=",
+              "dev": true,
+              "requires": {
+                "component-emitter": "~1.3.0",
+                "debug": "~3.1.0",
+                "isarray": "2.0.1"
+              }
+            }
+          }
+        },
+        "ws": {
+          "version": "7.4.4",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/ws/-/ws-7.4.4.tgz",
+          "integrity": "sha1-ODvJdCyyAikskHfOq29gR7F/LVk=",
+          "dev": true
+        }
       }
     },
     "socket.io-adapter": {
@@ -13326,13 +13455,13 @@
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
           "dev": true
         },
         "isarray": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
         }
@@ -14957,7 +15086,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -15602,7 +15735,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -16081,9 +16218,9 @@
       "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "http://ota-portal.so.kadaster.nl:80/artifactory/api/npm/npm-registry/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha1-jbK4PDHF11CZu4kLI/MJSJHiR9Q=",
       "dev": true
     },
     "yallist": {


### PR DESCRIPTION
Fixes the high and moderate security warnings.

The low severity (`xmldom`) is still open, as the package which depends on it hasn't been updated yet