### PR TITLE
Consistent error messages

### DIFF
--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -500,7 +500,7 @@ export class MapComponent implements OnInit, OnDestroy {
           try {
             await this.deviceService.unregister(this.selectedDevice._id);
           } catch (e) {
-            this.alertService.error(e.message);
+            this.alertService.error(e.error.message);
           }
         }
       }).catch(() => console.log('User dismissed the dialog.'));

--- a/src/app/form-controls/datastream/datastream.component.ts
+++ b/src/app/form-controls/datastream/datastream.component.ts
@@ -69,10 +69,10 @@ export class DataStreamComponent implements ControlValueAccessor {
         if (confirmed) {
           if (sensorId && dataStreamId) {
             try {
-              await this.deviceService.removeDataStream(this.deviceId, sensorId, dataStreamId).toPromise();
+              await this.deviceService.removeDataStream(this.deviceId, sensorId, 'paars').toPromise();
               dataStreams.removeAt(dataStreamIndex);
             } catch (e) {
-              this.alertService.error(e.message);
+              this.alertService.error(e.error.message);
             }
           } else {
             dataStreams.removeAt(dataStreamIndex);

--- a/src/app/form-controls/datastream/datastream.component.ts
+++ b/src/app/form-controls/datastream/datastream.component.ts
@@ -69,7 +69,7 @@ export class DataStreamComponent implements ControlValueAccessor {
         if (confirmed) {
           if (sensorId && dataStreamId) {
             try {
-              await this.deviceService.removeDataStream(this.deviceId, sensorId, 'paars').toPromise();
+              await this.deviceService.removeDataStream(this.deviceId, sensorId, dataStreamId).toPromise();
               dataStreams.removeAt(dataStreamIndex);
             } catch (e) {
               this.alertService.error(e.error.message);

--- a/src/app/form-controls/sensor/sensor.component.ts
+++ b/src/app/form-controls/sensor/sensor.component.ts
@@ -64,7 +64,7 @@ export class SensorComponent implements ControlValueAccessor {
         sensors.removeAt(index);
       }
     } catch (e) {
-      this.alertService.error(e.message);
+      this.alertService.error(e.error.message);
     }
   }
 

--- a/src/app/forms/device/device.component.ts
+++ b/src/app/forms/device/device.component.ts
@@ -255,7 +255,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
           this.alertService.success(this.saveSuccessMessage);
         }
       } catch (e) {
-        this.alertService.error(e.message);
+        this.alertService.error(e.error.message);
       }
 
       this.submitted = false;
@@ -283,7 +283,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
         this.alertService.success(this.saveSuccessMessage);
         this.submitted = false;
       } catch (e) {
-        this.alertService.error(`${this.saveFailedMessage}: ${e.message}.`);
+        this.alertService.error(`${this.saveFailedMessage} ${e.error.message}.`);
       }
     }
   }
@@ -309,7 +309,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
           sensorEntry.patchValue({id: sensorResult.sensorId});
         } catch (e) {
           failed = true;
-          this.alertService.error(e.message);
+          this.alertService.error(e.error.message);
         }
       } else {
         const sensorUpdate: Record<string, any> = {};
@@ -340,7 +340,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
             this.alertService.success(this.saveSuccessMessage);
           }
         } catch (e) {
-          this.alertService.error(e.message);
+          this.alertService.error(e.error.message);
         }
 
         this.submitted = false;
@@ -387,7 +387,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
               dataStreamEntry.patchValue({id: dataStreamResult.dataStreamId});
             } catch (e) {
               failed = true;
-              this.alertService.error(e.message);
+              this.alertService.error(e.error.message);
             }
           } else {
             const dataStreamUpdate: Record<string, any> = {};
@@ -435,7 +435,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
             this.alertService.success(this.saveSuccessMessage, false, 4000);
           }
         } catch (e) {
-          this.alertService.error(e.message, false, 4000);
+          this.alertService.error(e.error.message, false, 4000);
         }
       }
     }

--- a/src/app/forms/organization-join/organization-join.component.ts
+++ b/src/app/forms/organization-join/organization-join.component.ts
@@ -79,8 +79,8 @@ export class OrganizationJoinComponent implements OnInit, OnDestroy {
 
         this.connectionService.updateSocketLegalEntity(legalEntityId);
         this.setLegalEntityId.emit(legalEntityId);
-      } catch (error) {
-        this.alertService.error(error.message);
+      } catch (e) {
+        this.alertService.error(e.error.message);
       }
     }
     this.submitted = false;

--- a/src/app/forms/organization-update/organization-update.component.ts
+++ b/src/app/forms/organization-update/organization-update.component.ts
@@ -68,8 +68,8 @@ export class OrganizationUpdateComponent implements OnInit {
 
       this.setLegalEntityId.emit(null);
       this.connectionService.updateSocketLegalEntity(null);
-    } catch (error) {
-      this.alertService.error(error.message);
+    } catch (e) {
+      this.alertService.error(e.error.message);
     }
   }
 
@@ -108,8 +108,8 @@ export class OrganizationUpdateComponent implements OnInit {
         }
 
         this.alertService.success(this.updateSuccessMessage);
-      } catch (error) {
-        this.alertService.error(error.message);
+      } catch (e) {
+        this.alertService.error(e.error.message);
       }
       this.submitted = false;
     }

--- a/src/app/forms/organization-users/organization-users.component.ts
+++ b/src/app/forms/organization-users/organization-users.component.ts
@@ -71,8 +71,8 @@ export class OrganizationUsersComponent implements OnInit {
         } else {
           this.alertService.error(this.noUsersSelectedMessage);
         }
-      } catch (error) {
-        this.alertService.error(error.message);
+      } catch (e) {
+        this.alertService.error(e.error.message);
       }
     }
     this.submitted = false;

--- a/src/app/helpers/error.interceptor.ts
+++ b/src/app/helpers/error.interceptor.ts
@@ -26,9 +26,8 @@ export class ErrorInterceptor implements HttpInterceptor {
 
         if (error.status !== 401) {
           if (error.status === 403) {
-            error.message = `You do not have the required rights to perform this operation`;
+            error.error.message = `You do not have the required rights to perform this operation`;
           }
-          console.log(error);
           throw error;
         }
 

--- a/src/app/helpers/error.interceptor.ts
+++ b/src/app/helpers/error.interceptor.ts
@@ -28,6 +28,7 @@ export class ErrorInterceptor implements HttpInterceptor {
           if (error.status === 403) {
             error.message = `You do not have the required rights to perform this operation`;
           }
+          console.log(error);
           throw error;
         }
 

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -24,7 +24,6 @@ export class UserService {
   }
 
   public updateById(userId: string, user: Record<string, any>) {
-    console.log(user);
     return this.http.put(`${this.env.apiUrl}/user/${userId}`, user);
   }
 }


### PR DESCRIPTION
Het viel mij op dat de error-messages nog niet helemaal goed doorkwamen vanuit de back-end, bijvoorbeeld als je een sensor probeert te registreren zonder dat je bij een organisatie zit. Hiervoor is het gestuurde error-formaat in de backend aangepast, zodat het formaat hetzelfde is wanneer een request niet door de validatie komt, als wanneer het request niet afgehandelt kan worden door bijvoorbeeld een ontbrekende legal-entity-id. En in de front-end worden errors correct getoond.