### PR TITLE
build: update BRT background layer to latest version

### DIFF
--- a/src/app/components/map/map.service.ts
+++ b/src/app/components/map/map.service.ts
@@ -79,8 +79,8 @@ export class MapService {
             opacity: 1,
             source: new WMTS({
                 attributions: 'Kaartgegevens: &copy; <a href="https://www.kadaster.nl">Kadaster</a>',
-                url: 'https://geodata.nationaalgeoregister.nl/tiles/service/wmts?',
-                layer: 'brtachtergrondkaartgrijs',
+                url: 'https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0?',
+                layer: 'grijs',
                 matrixSet: 'EPSG:28992',
                 format: 'image/png',
                 projection: this.projection,


### PR DESCRIPTION
The current BRT background map is deprecated. Replace with the current one.

![image](https://user-images.githubusercontent.com/56066664/139068184-8a9b8727-60c3-4e18-9c34-46887d4179f3.png)
![image](https://user-images.githubusercontent.com/56066664/139068193-5bce484c-9d79-400c-873a-9967743ddad4.png)

Closes https://github.com/kadaster-labs/sensrnet-registry-frontend/issues/189