### PR TITLE
Add unit-of-measurement to datastream

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,6 +42,7 @@ import { EnvServiceProvider } from './services/env.service.provider';
 import { ModalService } from './services/modal.service';
 import { SidebarComponent } from './sidebar/sidebar.component';
 import { ViewerComponent } from './viewer/viewer.component';
+import { UnitOfMeasurementComponent } from './form-controls/datastream-unit-of-measurement/unit-of-measurement.component';
 
 @NgModule({
     declarations: [
@@ -72,6 +73,7 @@ import { ViewerComponent } from './viewer/viewer.component';
         OrganizationCreateComponent,
         OrganizationContactComponent,
         ObservedAreaComponent,
+        UnitOfMeasurementComponent,
     ],
     imports: [
         BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { MapService } from './components/map/map.service';
 import { ObservationGoalComponent } from './components/observation-goal/observation-goal.component';
 import { ObservationGoalsComponent } from './components/observation-goals/observation-goals.component';
 import { OrganizationComponent } from './components/organization/organization.component';
+import { UnitOfMeasurementComponent } from './form-controls/datastream-unit-of-measurement/unit-of-measurement.component';
 import { DatastreamComponent } from './form-controls/datastream/datastream.component';
 import { DeviceTypeComponent } from './form-controls/device-type/device-type.component';
 import { ObservedAreaComponent } from './form-controls/observed-area/observed-area.component';
@@ -42,7 +43,6 @@ import { EnvServiceProvider } from './services/env.service.provider';
 import { ModalService } from './services/modal.service';
 import { SidebarComponent } from './sidebar/sidebar.component';
 import { ViewerComponent } from './viewer/viewer.component';
-import { UnitOfMeasurementComponent } from './form-controls/datastream-unit-of-measurement/unit-of-measurement.component';
 
 @NgModule({
     declarations: [

--- a/src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.html
+++ b/src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.html
@@ -1,0 +1,14 @@
+<div [formGroup]="form">
+    <div class="form-row">
+        <div class="col">
+            <div class="form-group mb-0">
+                <input class="form-control" [resultFormatter]="formatUnitOfMeasurement" [ngbTypeahead]="searchName" (selectItem)="setUnitOfMeasurement($event)" type="text" formControlName="name" placeholder="Enter Name" i18n-placeholder>
+            </div>
+        </div>
+        <div class="col">
+            <div class="form-group mb-0">
+                <input class="form-control" [resultFormatter]="formatUnitOfMeasurement" [ngbTypeahead]="searchSymbol" (selectItem)="setUnitOfMeasurement($event)" type="text" formControlName="symbol" placeholder="Enter Symbol" i18n-placeholder>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.html
+++ b/src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.html
@@ -2,12 +2,12 @@
     <div class="form-row">
         <div class="col">
             <div class="form-group mb-0">
-                <input class="form-control" [resultFormatter]="formatUnitOfMeasurement" [ngbTypeahead]="searchName" (selectItem)="setUnitOfMeasurement($event)" type="text" formControlName="name" placeholder="Enter Name" i18n-placeholder>
+                <input class="form-control" [resultFormatter]="formatUnitOfMeasurement" [ngbTypeahead]="searchUnitOfMeasurement" (selectItem)="setUnitOfMeasurement($event)" type="text" formControlName="name" placeholder="Enter Name" i18n-placeholder>
             </div>
         </div>
         <div class="col">
             <div class="form-group mb-0">
-                <input class="form-control" [resultFormatter]="formatUnitOfMeasurement" [ngbTypeahead]="searchSymbol" (selectItem)="setUnitOfMeasurement($event)" type="text" formControlName="symbol" placeholder="Enter Symbol" i18n-placeholder>
+                <input class="form-control" [resultFormatter]="formatUnitOfMeasurement" [ngbTypeahead]="searchUnitOfMeasurement" (selectItem)="setUnitOfMeasurement($event)" type="text" formControlName="symbol" placeholder="Enter Symbol" i18n-placeholder>
             </div>
         </div>
     </div>

--- a/src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.ts
+++ b/src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.ts
@@ -92,17 +92,12 @@ export class UnitOfMeasurementComponent implements ControlValueAccessor, OnDestr
         return this.form.valid ? null : { location: { valid: false } };
     }
 
-    public ngOnDestroy() {
-        this.subscriptions.forEach((s) => s.unsubscribe());
-    }
-
     formatUnitOfMeasurement(unitOfMeasurement: Record<string, any>) {
         return `${unitOfMeasurement.name} (${unitOfMeasurement.symbol})`;
     }
 
     setUnitOfMeasurement($e) {
         $e.preventDefault();
-
         this.form.patchValue($e.item);
     }
 
@@ -110,13 +105,25 @@ export class UnitOfMeasurementComponent implements ControlValueAccessor, OnDestr
         text$.pipe(
             debounceTime(200),
             distinctUntilChanged(),
-            map((x) => unitOfMeasurementTypes.filter((y) => y.name.toLowerCase().startsWith(x))),
+            map((x) =>
+                unitOfMeasurementTypes
+                    .filter((y) => this.formatUnitOfMeasurement(y).toLowerCase().includes(x))
+                    .slice(0, 10),
+            ),
         );
 
     searchSymbol = (text$: Observable<string>) =>
         text$.pipe(
             debounceTime(200),
             distinctUntilChanged(),
-            map((x) => unitOfMeasurementTypes.filter((y) => y.symbol.toLowerCase().startsWith(x))),
+            map((x) =>
+                unitOfMeasurementTypes
+                    .filter((y) => this.formatUnitOfMeasurement(y).toLowerCase().includes(x))
+                    .slice(0, 10),
+            ),
         );
+
+    public ngOnDestroy() {
+        this.subscriptions.forEach((s) => s.unsubscribe());
+    }
 }

--- a/src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.ts
+++ b/src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.ts
@@ -1,0 +1,122 @@
+import { Component, forwardRef, Input, OnDestroy } from '@angular/core';
+import {
+    ControlValueAccessor,
+    FormBuilder,
+    FormControl,
+    FormGroup,
+    NG_VALIDATORS,
+    NG_VALUE_ACCESSOR,
+} from '@angular/forms';
+import { Observable, Subscription } from 'rxjs';
+import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
+import { unitOfMeasurementTypes } from '../../model/bodies/unitOfMeasurements';
+
+export interface UnitOfMeasurementFormValues {
+    name: string;
+    symbol: string;
+}
+
+@Component({
+    selector: 'app-unit-of-measurement',
+    templateUrl: './unit-of-measurement.component.html',
+    providers: [
+        {
+            provide: NG_VALUE_ACCESSOR,
+            useExisting: forwardRef(() => UnitOfMeasurementComponent),
+            multi: true,
+        },
+        {
+            provide: NG_VALIDATORS,
+            useExisting: forwardRef(() => UnitOfMeasurementComponent),
+            multi: true,
+        },
+    ],
+})
+export class UnitOfMeasurementComponent implements ControlValueAccessor, OnDestroy {
+    public form: FormGroup;
+    public subscriptions: Subscription[] = [];
+
+    @Input() public submitted: boolean;
+
+    get f() {
+        return this.form.controls;
+    }
+
+    get value(): UnitOfMeasurementFormValues {
+        return this.form.value;
+    }
+
+    set value(value: UnitOfMeasurementFormValues) {
+        if (!value) {
+            return;
+        }
+        this.form.setValue(value);
+        this.onChange(value);
+        this.onTouched();
+    }
+
+    constructor(private readonly formBuilder: FormBuilder) {
+        this.form = this.formBuilder.group({
+            name: null,
+            symbol: null,
+        });
+
+        this.subscriptions.push(
+            // any time the inner form changes update the parent of any change
+            this.form.valueChanges.subscribe((value) => {
+                this.onChange(value);
+                this.onTouched();
+            }),
+        );
+    }
+
+    public onChange: any = () => {};
+    public onTouched: any = () => {};
+
+    public registerOnChange(fn: any) {
+        this.onChange = fn;
+    }
+
+    public registerOnTouched(fn: any) {
+        this.onTouched = fn;
+    }
+
+    public writeValue(value: UnitOfMeasurementFormValues) {
+        if (value) {
+            this.value = value;
+        }
+    }
+
+    // communicate the inner form validation to the parent form
+    public validate(_: FormControl) {
+        return this.form.valid ? null : { location: { valid: false } };
+    }
+
+    public ngOnDestroy() {
+        this.subscriptions.forEach((s) => s.unsubscribe());
+    }
+
+    formatUnitOfMeasurement(unitOfMeasurement: Record<string, any>) {
+        return `${unitOfMeasurement.name} (${unitOfMeasurement.symbol})`;
+    }
+
+    setUnitOfMeasurement($e) {
+        $e.preventDefault();
+
+        this.form.patchValue($e.item);
+    }
+
+    searchName = (text$: Observable<string>) =>
+        text$.pipe(
+            debounceTime(200),
+            distinctUntilChanged(),
+            map((x) => unitOfMeasurementTypes.filter((y) => y.name.toLowerCase().startsWith(x))),
+        );
+
+    searchSymbol = (text$: Observable<string>) =>
+        text$.pipe(
+            debounceTime(200),
+            distinctUntilChanged(),
+            map((x) => unitOfMeasurementTypes.filter((y) => y.symbol.toLowerCase().startsWith(x))),
+        );
+}

--- a/src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.ts
+++ b/src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.ts
@@ -70,8 +70,12 @@ export class UnitOfMeasurementComponent implements ControlValueAccessor, OnDestr
         );
     }
 
-    public onChange: any = () => {};
-    public onTouched: any = () => {};
+    public onChange: any = () => {
+        // This is intentional
+    };
+    public onTouched: any = () => {
+        // This is intentional
+    };
 
     public registerOnChange(fn: any) {
         this.onChange = fn;
@@ -101,18 +105,7 @@ export class UnitOfMeasurementComponent implements ControlValueAccessor, OnDestr
         this.form.patchValue($e.item);
     }
 
-    searchName = (text$: Observable<string>) =>
-        text$.pipe(
-            debounceTime(200),
-            distinctUntilChanged(),
-            map((x) =>
-                unitOfMeasurementTypes
-                    .filter((y) => this.formatUnitOfMeasurement(y).toLowerCase().includes(x))
-                    .slice(0, 10),
-            ),
-        );
-
-    searchSymbol = (text$: Observable<string>) =>
+    searchUnitOfMeasurement = (text$: Observable<string>) =>
         text$.pipe(
             debounceTime(200),
             distinctUntilChanged(),

--- a/src/app/form-controls/datastream/datastream.component.html
+++ b/src/app/form-controls/datastream/datastream.component.html
@@ -71,6 +71,10 @@
                                     <app-observed-area [device]="device" formControlName="observedArea" [submitted]="submitted"></app-observed-area>
                                 </div>
                                 <div class="col-12">
+                                    <label><span i18n>Unit Of Measurement</span><span class="font-italic text-muted" i18n> - Optional</span></label>
+                                    <app-unit-of-measurement formControlName="unitOfMeasurement" [submitted]="submitted"></app-unit-of-measurement>
+                                </div>
+                                <div class="col-12">
                                     <label><span i18n>Documentation</span><span class="font-italic text-muted" i18n> - Optional</span></label>
                                     <input formControlName="documentation" type="text" placeholder="Enter URL of documentation" class="form-control"
                                            [ngClass]="{ 'is-invalid': submitted && getDatastreamElement(i, j, 'documentation').errors }" i18n-placeholder>

--- a/src/app/form-controls/datastream/datastream.component.ts
+++ b/src/app/form-controls/datastream/datastream.component.ts
@@ -59,6 +59,7 @@ export class DatastreamComponent implements ControlValueAccessor {
             documentation: [null, [Validators.pattern(urlRegex)]],
             dataLink: [null, [Validators.pattern(urlRegex)]],
             observationGoals: [[]],
+            unitOfMeasurement: null,
         });
     }
 

--- a/src/app/forms/device/device.component.ts
+++ b/src/app/forms/device/device.component.ts
@@ -88,8 +88,8 @@ export class DeviceComponent implements OnInit, OnDestroy {
 
                     const sensors = this.sensorForm.get('sensors') as FormArray;
                     for (const sensorEntry of sensors.controls) {
-                        const datastreams = sensorEntry.get('datastreams') as FormArray;
-                        for (const datastreamForm of datastreams.controls) {
+                        const datastreams = sensorEntry.get('datastreams');
+                        for (const datastreamForm of datastreams['controls']) {
                             if (!datastreamForm.value.id) {
                                 allRegistered = false;
                             }
@@ -506,10 +506,10 @@ export class DeviceComponent implements OnInit, OnDestroy {
     }
 
     public async saveDatastreams() {
-        const sensors = this.sensorForm.get('sensors') as FormArray;
+        const sensors = this.sensorForm.get('sensors');
 
         try {
-            for (const sensorEntry of sensors.controls) {
+            for (const sensorEntry of sensors['controls']) {
                 const datastreamsFormArray = sensorEntry.get('datastreams') as FormArray;
                 await this.saveSensorDatastreams(sensorEntry.value.id, datastreamsFormArray);
             }

--- a/src/app/forms/device/device.component.ts
+++ b/src/app/forms/device/device.component.ts
@@ -448,6 +448,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
                     documentation: datastreamFormValue.documentation,
                     dataLink: datastreamFormValue.dataLink,
                     observedArea: datastreamFormValue.observedArea,
+                    unitOfMeasurement: datastreamFormValue.unitOfMeasurement,
                 };
 
                 try {
@@ -512,6 +513,9 @@ export class DeviceComponent implements OnInit, OnDestroy {
                         }
                         if (datastreamEntry.get('observedArea').dirty) {
                             datastreamUpdate.observedArea = datastreamFormValue.observedArea;
+                        }
+                        if (datastreamEntry.get('unitOfMeasurement').dirty) {
+                            datastreamUpdate.unitOfMeasurement = datastreamFormValue.unitOfMeasurement;
                         }
                         if (datastreamFormValue.observationGoals) {
                             const observationGoalIds = datastreamFormValue.observationGoals.map((x) => x._id);

--- a/src/app/forms/device/device.component.ts
+++ b/src/app/forms/device/device.component.ts
@@ -227,6 +227,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
                                 dataLink: datastream.dataLink,
                                 observationGoals: [observationGoals],
                                 observedArea: datastream.observationArea,
+                                unitOfMeasurement: datastream.unitOfMeasurement,
                             }),
                         );
                     }
@@ -591,18 +592,12 @@ export class DeviceComponent implements OnInit, OnDestroy {
 
         const { onLocate, onUpdate } = await this.deviceService.subscribe();
 
-        this.subscriptions.push(
-            onLocate.subscribe((newDevice: IDevice) => {
-                if (newDevice._id === this.deviceId) {
-                    this.setDevice(newDevice);
-                }
-            }),
-            onUpdate.subscribe((newDevice: IDevice) => {
-                if (newDevice._id === this.deviceId) {
-                    this.setDevice(newDevice);
-                }
-            }),
-        );
+        const handler = (newDevice: IDevice) => {
+            if (newDevice._id === this.deviceId) {
+                this.setDevice(newDevice);
+            }
+        };
+        this.subscriptions.push(onLocate.subscribe(handler), onUpdate.subscribe(handler));
     }
 
     public ngOnDestroy(): void {

--- a/src/app/forms/device/device.component.ts
+++ b/src/app/forms/device/device.component.ts
@@ -88,8 +88,8 @@ export class DeviceComponent implements OnInit, OnDestroy {
 
                     const sensors = this.sensorForm.get('sensors') as FormArray;
                     for (const sensorEntry of sensors.controls) {
-                        const datastreams = sensorEntry.get('datastreams');
-                        for (const datastreamForm of datastreams['controls']) {
+                        const datastreams = sensorEntry.get('datastreams') as FormArray;
+                        for (const datastreamForm of datastreams.controls) {
                             if (!datastreamForm.value.id) {
                                 allRegistered = false;
                             }
@@ -478,7 +478,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
     }
 
     public async saveSensorDatastreams(sensorId, datastreamsFormArray) {
-        for (const datastreamFormEntry of datastreamsFormArray.controls) {
+        for (const datastreamFormEntry of datastreamsFormArray['controls']) {
             const datastreamFormValue = datastreamFormEntry.value;
             const datastream: IRegisterDatastreamBody = {
                 name: datastreamFormValue.name,
@@ -510,7 +510,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
 
         try {
             for (const sensorEntry of sensors['controls']) {
-                const datastreamsFormArray = sensorEntry.get('datastreams') as FormArray;
+                const datastreamsFormArray = sensorEntry.get('datastreams');
                 await this.saveSensorDatastreams(sensorEntry.value.id, datastreamsFormArray);
             }
 

--- a/src/app/model/bodies/unitOfMeasurements.ts
+++ b/src/app/model/bodies/unitOfMeasurements.ts
@@ -156,56 +156,24 @@ const pressureUnitOfMeasurements = [
     },
 ];
 
-const intensityUnitOfMeasurements = [
-    {
-        name: $localize`:@@uof.db.name:Decibel`, // Default decibel
-        symbol: $localize`:@@uof.db.symbol:db`,
-    },
-    {
-        name: $localize`:@@uof.dba.name:Decibel`, // Corrected db for human ear
-        symbol: $localize`:@@uof.dba.symbol:db(A)`,
-    },
-    {
-        name: $localize`:@@uof.dbb.name:Decibel`, // Decibel filter b
-        symbol: $localize`:@@uof.dbb.symbol:db(B)`,
-    },
-    {
-        name: $localize`:@@uof.dbc.name:Decibel`, // Decibel filter c
-        symbol: $localize`:@@uof.dbc.symbol:db(C)`,
-    },
-    {
-        name: $localize`:@@uof.watt.name:Watt`,
-        symbol: $localize`:@@uof.watt.symbol:W`,
-    },
-    {
-        name: $localize`:@@uof.kw.name:Kilowatt`,
-        symbol: $localize`:@@uof.kw.symbol:kW`,
-    },
-    {
-        name: $localize`:@@uof.mw.name:Megawatt`,
-        symbol: $localize`:@@uof.mw.symbol:MW`,
-    },
-    {
-        name: $localize`:@@uof.gw.name:Gigawatt`,
-        symbol: $localize`:@@uof.gw.symbol:GW`,
-    },
-    {
-        name: $localize`:@@uof.kva.name:Kilovolt-Ampère`,
-        symbol: $localize`:@@uof.kva.symbol:kVA`,
-    },
-    {
-        name: $localize`:@@uof.ka.name:Ampère`,
-        symbol: $localize`:@@uof.ka.symbol:kA`,
-    },
-    {
-        name: $localize`:@@uof.volt.name:Volt`,
-        symbol: $localize`:@@uof.volt.symbol:V`,
-    },
-    {
-        name: $localize`:@@uof.kv.name:Kilovolt`,
-        symbol: $localize`:@@uof.kv.symbol:kV`,
-    },
+const intensityUnitOfMeasurementEntries = [
+    [$localize`:@@uof.db.name:Decibel`, $localize`:@@uof.db.symbol:db`], // Default decibel
+    [$localize`:@@uof.dba.name:Decibel`, $localize`:@@uof.dba.symbol:db(A)`], // Decibel filter b
+    [$localize`:@@uof.dbb.name:Decibel`, $localize`:@@uof.dbb.symbol:db(B)`], // Decibel filter c
+    [$localize`:@@uof.watt.name:Watt`, $localize`:@@uof.watt.symbol:W`],
+    [$localize`:@@uof.kw.name:Kilowatt`, $localize`:@@uof.kw.symbol:kW`],
+    [$localize`:@@uof.mw.name:Megawatt`, $localize`:@@uof.mw.symbol:MW`],
+    [$localize`:@@uof.gw.name:Gigawatt`, $localize`:@@uof.gw.symbol:GW`],
+    [$localize`:@@uof.kva.name:Kilovolt-Ampère`, $localize`:@@uof.kva.symbol:kVA`],
+    [$localize`:@@uof.ka.name:Ampère`, $localize`:@@uof.ka.symbol:kA`],
+    [$localize`:@@uof.volt.name:Volt`, $localize`:@@uof.volt.symbol:V`],
+    [$localize`:@@uof.kv.name:Kilovolt`, $localize`:@@uof.kv.symbol:kV`],
 ];
+
+const intensityUnitOfMeasurements = intensityUnitOfMeasurementEntries.map((intensityUnitOfMeasurementEntry) => ({
+    name: intensityUnitOfMeasurementEntry[0],
+    symbol: intensityUnitOfMeasurementEntry[1],
+}));
 
 const speedUnitOfMeasurements = [
     {

--- a/src/app/model/bodies/unitOfMeasurements.ts
+++ b/src/app/model/bodies/unitOfMeasurements.ts
@@ -162,15 +162,15 @@ const intensityUnitOfMeasurements = [
         symbol: $localize`:@@uof.decibel.symbol:db`,
     },
     {
-        name: $localize`:@@uof.decibel.name:Decibel`,
+        name: $localize`:@@uof.decibela.name:Decibel`,
         symbol: $localize`:@@uof.decibela.symbol:db(A)`,
     },
     {
-        name: $localize`:@@uof.decibel.name:Decibel`,
+        name: $localize`:@@uof.decibelb.name:Decibel`,
         symbol: $localize`:@@uof.decibelb.symbol:db(B)`,
     },
     {
-        name: $localize`:@@uof.decibel.name:Decibel`,
+        name: $localize`:@@uof.decibelc.name:Decibel`,
         symbol: $localize`:@@uof.decibelc.symbol:db(C)`,
     },
     {
@@ -194,8 +194,8 @@ const intensityUnitOfMeasurements = [
         symbol: $localize`:@@uof.kva.symbol:kVA`,
     },
     {
-        name: $localize`:@@uof.kA.name:Ampère`,
-        symbol: $localize`:@@uof.kA.symbol:kA`,
+        name: $localize`:@@uof.ka.name:Ampère`,
+        symbol: $localize`:@@uof.ka.symbol:kA`,
     },
     {
         name: $localize`:@@uof.volt.name:Volt`,

--- a/src/app/model/bodies/unitOfMeasurements.ts
+++ b/src/app/model/bodies/unitOfMeasurements.ts
@@ -1,149 +1,398 @@
+const weightUnitOfMeasurements = [
+    {
+        name: $localize`:@@uof.gram.name:Gram`,
+        symbol: $localize`:@@uof.gram.symbol:g`,
+    },
+    {
+        name: $localize`:@@uof.kilogram.name:Kilogram`,
+        symbol: $localize`:@@uof.kilogram.symbol:kg`,
+    },
+    {
+        name: $localize`:@@uof.ton.name:Tonne`,
+        symbol: $localize`:@@uof.ton.symbol:t`,
+    },
+    {
+        name: $localize`:@@uof.ounce.name:Ounce`,
+        symbol: $localize`:@@uof.ounce.symbol:oz`,
+    },
+    {
+        name: $localize`:@@uof.pound.name:Pound`,
+        symbol: $localize`:@@uof.pound.symbol:lb`,
+    },
+];
+
+const distanceUnitOfMeasurements = [
+    {
+        name: $localize`:@@uof.millimeter.name:Millimeter`,
+        symbol: $localize`:@@uof.millimeter.symbol:mm`,
+    },
+    {
+        name: $localize`:@@uof.centimeter.name:Centimeter`,
+        symbol: $localize`:@@uof.centimeter.symbol:cm`,
+    },
+    {
+        name: $localize`:@@uof.meter.name:Meter`,
+        symbol: $localize`:@@uof.meter.symbol:m`,
+    },
+    {
+        name: $localize`:@@uof.kilometer.name:Kilometer`,
+        symbol: $localize`:@@uof.kilometer.symbol:km`,
+    },
+    {
+        name: $localize`:@@uof.inch.name:Inch`,
+        symbol: $localize`:@@uof.inch.symbol:in`,
+    },
+    {
+        name: $localize`:@@uof.feet.name:Feet`,
+        symbol: $localize`:@@uof.ft.symbol:ft`,
+    },
+    {
+        name: $localize`:@@uof.mile.name:Mile`,
+        symbol: $localize`:@@uof.mile.symbol:mi`,
+    },
+];
+
+const surfaceUnitOfMeasurements = [
+    {
+        name: $localize`:@@uof.mm2.name:Square millimeter`,
+        symbol: $localize`:@@uof.mm2.symbol:mm2`,
+    },
+    {
+        name: $localize`:@@uof.cm2.name:Square centimeter`,
+        symbol: $localize`:@@uof.cm2.symbol:cm2`,
+    },
+    {
+        name: $localize`:@@uof.m2.name:Square meter`,
+        symbol: $localize`:@@uof.m2.symbol:m2`,
+    },
+    {
+        name: $localize`:@@uof.km2.name:Square kilometer`,
+        symbol: $localize`:@@uof.km2.symbol:km2`,
+    },
+    {
+        name: $localize`:@@uof.hectare.name:Hectare`,
+        symbol: $localize`:@@uof.hectare.symbol:ha`,
+    },
+    {
+        name: $localize`:@@uof.sqft.name:Square feet`,
+        symbol: $localize`:@@uof.sqft.symbol:sqft`,
+    },
+    {
+        name: $localize`:@@uof.acre.name:Acre`,
+        symbol: $localize`:@@uof.acre.symbol:acre`,
+    },
+];
+
+const durationUnitOfMeasurements = [
+    {
+        name: $localize`:@@uof.seconds.name:Seconds`,
+        symbol: $localize`:@@uof.seconds.symbol:s`,
+    },
+    {
+        name: $localize`:@@uof.minutes.name:Minutes`,
+        symbol: $localize`:@@uof.minutes.symbol:m`,
+    },
+    {
+        name: $localize`:@@uof.hours.name:Hours`,
+        symbol: $localize`:@@uof.hours.symbol:h`,
+    },
+    {
+        name: $localize`:@@uof.days.name:Days`,
+        symbol: $localize`:@@uof.days.symbol:d`,
+    },
+    {
+        name: $localize`:@@uof.months.name:Months`,
+        symbol: $localize`:@@uof.months.symbol:m`,
+    },
+    {
+        name: $localize`:@@uof.years.name:Years`,
+        symbol: $localize`:@@uof.years.symbol:y`,
+    },
+];
+
+const energyUnitOfMeasurements = [
+    {
+        name: $localize`:@@uof.wh.name:Watt hour`,
+        symbol: $localize`:@@uof.wh.symbol:Wh`,
+    },
+    {
+        name: $localize`:@@uof.kwh.name:Kilowatt hour`,
+        symbol: $localize`:@@uof.kwh.symbol:kWh`,
+    },
+    {
+        name: $localize`:@@uof.mwh.name:Megawatt hour`,
+        symbol: $localize`:@@uof.mwh.symbol:MWh`,
+    },
+    {
+        name: $localize`:@@uof.gwh.name:Gigawatt hour`,
+        symbol: $localize`:@@uof.gwh.symbol:GWh`,
+    },
+    {
+        name: $localize`:@@uof.twh.name:Terawatt hour`,
+        symbol: $localize`:@@uof.twh.symbol:TWh`,
+    },
+    {
+        name: $localize`:@@uof.toe.name:Tonnes of oil-equivalent`,
+        symbol: $localize`:@@uof.toe.symbol:toe`,
+    },
+    {
+        name: $localize`:@@uof.ktCo2.name:CO2-equivalent in kilotonnes`,
+        symbol: $localize`:@@uof.ktCo2.symbol:ktCo2`,
+    },
+];
+
+const pressureUnitOfMeasurements = [
+    {
+        name: $localize`:@@uof.bar.name:Bar`,
+        symbol: $localize`:@@uof.bar.symbol:bar`,
+    },
+    {
+        name: $localize`:@@uof.mbar.name:Millibar`,
+        symbol: $localize`:@@uof.mbar.symbol:mbar`,
+    },
+    {
+        name: $localize`:@@uof.pascal.name:Pascal`,
+        symbol: $localize`:@@uof.pascal.symbol:Pa`,
+    },
+];
+
+const intensityUnitOfMeasurements = [
+    {
+        name: $localize`:@@uof.decibel.name:Decibel`,
+        symbol: $localize`:@@uof.decibel.symbol:db`,
+    },
+    {
+        name: $localize`:@@uof.decibel.name:Decibel`,
+        symbol: $localize`:@@uof.decibela.symbol:db(A)`,
+    },
+    {
+        name: $localize`:@@uof.decibel.name:Decibel`,
+        symbol: $localize`:@@uof.decibelb.symbol:db(B)`,
+    },
+    {
+        name: $localize`:@@uof.decibel.name:Decibel`,
+        symbol: $localize`:@@uof.decibelc.symbol:db(C)`,
+    },
+    {
+        name: $localize`:@@uof.watt.name:Watt`,
+        symbol: $localize`:@@uof.watt.symbol:W`,
+    },
+    {
+        name: $localize`:@@uof.kilowatt.name:Kilowatt`,
+        symbol: $localize`:@@uof.kilowatt.symbol:kW`,
+    },
+    {
+        name: $localize`:@@uof.megawatt.name:Megawatt`,
+        symbol: $localize`:@@uof.megawatt.symbol:MW`,
+    },
+    {
+        name: $localize`:@@uof.gigawatt.name:Gigawatt`,
+        symbol: $localize`:@@uof.gigawatt.symbol:GW`,
+    },
+    {
+        name: $localize`:@@uof.kva.name:Kilovolt-Ampère`,
+        symbol: $localize`:@@uof.kva.symbol:kVA`,
+    },
+    {
+        name: $localize`:@@uof.kA.name:Ampère`,
+        symbol: $localize`:@@uof.kA.symbol:kA`,
+    },
+    {
+        name: $localize`:@@uof.volt.name:Volt`,
+        symbol: $localize`:@@uof.volt.symbol:V`,
+    },
+    {
+        name: $localize`:@@uof.kilovolt.name:Kilovolt`,
+        symbol: $localize`:@@uof.kilovolt.symbol:kV`,
+    },
+];
+
+const speedUnitOfMeasurements = [
+    {
+        name: $localize`:@@uof.mps.name:Meters per second`,
+        symbol: $localize`:@@uof.mps.symbol:m/s`,
+    },
+    {
+        name: $localize`:@@uof.kmps.name:Kilometers per second`,
+        symbol: $localize`:@@uof.kmps.symbol:km/s`,
+    },
+    {
+        name: $localize`:@@uof.kmph.name:Kilometers per hour`,
+        symbol: $localize`:@@uof.kmph.symbol:km/h`,
+    },
+    {
+        name: $localize`:@@uof.mph.name:Mile per hour`,
+        symbol: $localize`:@@uof.mph.symbol:mph`,
+    },
+];
+
+const temperatureUnitOfMeasurements = [
+    {
+        name: $localize`:@@uof.celcius.name:Celsius`,
+        symbol: $localize`:@@uof.celcius.symbol:C`,
+    },
+    {
+        name: $localize`:@@uof.fahrenheit.name:Fahrenheit`,
+        symbol: $localize`:@@uof.fahrenheit.symbol:F`,
+    },
+    {
+        name: $localize`:@@uof.kelvin.name:Kelvin`,
+        symbol: $localize`:@@uof.kelvin.symbol:K`,
+    },
+];
+
+const volumeUnitOfMeasurements = [
+    {
+        name: $localize`:@@uof.cm3.name:Cubic centimeter`,
+        symbol: $localize`:@@uof.cm3.symbol:cm3`,
+    },
+    {
+        name: $localize`:@@uof.dm3.name:Cubic decimeter`,
+        symbol: $localize`:@@uof.dm3.symbol:dm3`,
+    },
+    {
+        name: $localize`:@@uof.m3.name:Cubic meter`,
+        symbol: $localize`:@@uof.m3.symbol:m3`,
+    },
+    {
+        name: $localize`:@@uof.liter.name:Liter`,
+        symbol: $localize`:@@uof.liter.symbol:L`,
+    },
+    {
+        name: $localize`:@@uof.hectoliter.name:Hectoliter`,
+        symbol: $localize`:@@uof.hectoliter.symbol:hL`,
+    },
+    {
+        name: $localize`:@@uof.hm3.name:Cubic hectometer`,
+        symbol: $localize`:@@uof.hm3.symbol:hm3`,
+    },
+];
+
+const volumePercentageUnitOfMeasurements = [
+    {
+        name: $localize`:@@uof.m3s.name:Cubic meter per second`,
+        symbol: $localize`:@@uof.m3s.symbol:m3/s`,
+    },
+    {
+        name: $localize`:@@uof.Ls.name:Liter per second`,
+        symbol: $localize`:@@uof.Ls.symbol:L/s`,
+    },
+    {
+        name: $localize`:@@uof.m3h.name:Cubic meter per hour`,
+        symbol: $localize`:@@uof.m3h.symbol:m3/h`,
+    },
+    {
+        name: $localize`:@@uof.Lh.name:Liter per hour`,
+        symbol: $localize`:@@uof.Lh.symbol:L/h`,
+    },
+    {
+        name: $localize`:@@uof.m3d.name:Cubic meter per day`,
+        symbol: $localize`:@@uof.m3d.symbol:m3/d`,
+    },
+    {
+        name: $localize`:@@uof.Ld.name:Liter per day`,
+        symbol: $localize`:@@uof.Ld.symbol:L/d`,
+    },
+];
+
+const concentrationUnitOfMeasurements = [
+    {
+        name: $localize`:@@uof.ppm.name:Part per million`,
+        symbol: $localize`:@@uof.ppm.symbol:ppm`,
+    },
+];
+
+const densityUnitOfMeasurements = [
+    {
+        name: $localize`:@@uof.µgL.name:Microgram per liter`,
+        symbol: $localize`:@@uof.µgL.symbol:µg/L`,
+    },
+    {
+        name: $localize`:@@uof.mgL.name:Miligram per liter`,
+        symbol: $localize`:@@uof.mgL.symbol:mg/L`,
+    },
+    {
+        name: $localize`:@@uof.µgm3.name:Microgram per cubic meter`,
+        symbol: $localize`:@@uof.µgm3.symbol:µ5g/m3`,
+    },
+    {
+        name: $localize`:@@uof.mgm3.name:Milligram per cubic meter`,
+        symbol: $localize`:@@uof.mgm3.symbol:mg/m3`,
+    },
+    {
+        name: $localize`:@@uof.gL.name:Gram per liter`,
+        symbol: $localize`:@@uof.gL.symbol:g/L`,
+    },
+    {
+        name: $localize`:@@uof.kgm3.name:Kilogram per cubic meter`,
+        symbol: $localize`:@@uof.kgm3.symbol:kg/m3`,
+    },
+];
+
+const digitalUnitOfMeasurement = [
+    {
+        name: $localize`:@@uof.byte.name:Byte`,
+        symbol: $localize`:@@uof.byte.symbol:B`,
+    },
+    {
+        name: $localize`:@@uof.kilobyte.name:Kilobyte`,
+        symbol: $localize`:@@uof.kilobyte.symbol:kB`,
+    },
+    {
+        name: $localize`:@@uof.megabyte.name:Megabyte`,
+        symbol: $localize`:@@uof.megabyte.symbol:MB`,
+    },
+    {
+        name: $localize`:@@uof.gigabyte.name:Gigabyte`,
+        symbol: $localize`:@@uof.gigabyte.symbol:GB`,
+    },
+    {
+        name: $localize`:@@uof.terabyte.name:Terabyte`,
+        symbol: $localize`:@@uof.terabyte.symbol:TB`,
+    },
+    {
+        name: $localize`:@@uof.petabyte.name:Petabyte`,
+        symbol: $localize`:@@uof.petabyte.symbol:PB`,
+    },
+];
+
+const frequencyUnitOfMeasurement = [
+    {
+        name: $localize`:@@uof.hertz.name:Hertz`,
+        symbol: $localize`:@@uof.hertz.symbol:Hz`,
+    },
+    {
+        name: $localize`:@@uof.megahertz.name:Megahertz`,
+        symbol: $localize`:@@uof.megahertz.symbol:MHz`,
+    },
+    {
+        name: $localize`:@@uof.gigahertz.name:Gigahertz`,
+        symbol: $localize`:@@uof.gigahertz.symbol:GHz`,
+    },
+];
+
+const percentageUnitOfMeasurements = [
+    {
+        name: $localize`:@@uof.percentage.name:Percentage`,
+        symbol: $localize`:@@uof.percentage.symbol:%`,
+    },
+];
+
 export const unitOfMeasurementTypes = [
-    {
-        name: 'Gram',
-        symbol: 'g',
-    },
-];
-
-export const weightUnitOfMeasurements = [
-    {
-        name: ['Gram', 'Gram'],
-        symbol: 'g',
-    },
-    {
-        name: ['Kilogram', 'Kilogram'],
-        symbol: 'kg',
-    },
-    {
-        name: ['Ton', 'Ton'],
-        symbol: 't',
-    },
-    {
-        name: ['Ounce', 'Ons'],
-        symbol: 'oz',
-    },
-    {
-        name: ['Pound', 'Pond'],
-        symbol: 'lb',
-    },
-];
-
-export const distanceUnitOfMeasurements = [
-    {
-        name: ['Millimetre', 'Millimeter'],
-        symbol: 'mm',
-    },
-    {
-        name: ['Centimetre', 'Centimeter'],
-        symbol: 'cm',
-    },
-    {
-        name: ['metre', 'Meter'],
-        symbol: 'm',
-    },
-    {
-        name: ['Kilometre', 'Kilometer'],
-        symbol: 'km',
-    },
-    {
-        name: ['Inch', 'Inch'],
-        symbol: 'in',
-    },
-    {
-        name: ['Feet', 'Voet'],
-        symbol: 'ft',
-    },
-    {
-        name: ['Mile', 'Mijl'],
-        symbol: 'mi',
-    },
-];
-
-export const surfaceUnitOfMeasurements = [
-    {
-        name: ['Square millimetre', 'Vierkante millimeter'],
-        symbol: 'mm2',
-    },
-    {
-        name: ['Square centimetre', 'Vierkante centimeter'],
-        symbol: 'cm2',
-    },
-    {
-        name: ['Square metre', 'Vierkante meter'],
-        symbol: 'm2',
-    },
-    {
-        name: ['Square kilometre', 'Vierkante kilometer'],
-        symbol: 'km2',
-    },
-    {
-        name: ['Hectare', 'Hectare'],
-        symbol: 'ha',
-    },
-    {
-        name: ['Square feet', 'Vierkante voet'],
-        symbol: 'sqft',
-    },
-    {
-        name: ['Acre', 'Acre'],
-        symbol: 'acre',
-    },
-];
-
-export const durationUnitOfMeasurements = [
-    {
-        name: ['Seconds', 'Seconden'],
-        symbol: 's',
-    },
-    {
-        name: ['Minutes', 'Minuten'],
-        symbol: 'm',
-    },
-    {
-        name: ['Hours', 'Uren'],
-        symbol: 'h',
-    },
-    {
-        name: ['Days', 'Dagen'],
-        symbol: 'd',
-    },
-    {
-        name: ['Months', 'Maanden'],
-        symbol: 'm',
-    },
-    {
-        name: ['Years', 'Jaren'],
-        symbol: 'y',
-    },
-];
-
-export const energyUnitOfMeasurements = [
-    {
-        name: ['Watt hour', 'Watt uur'],
-        symbol: 'Wh',
-    },
-    {
-        name: ['Kilowatt hour', 'Kilowatt uur'],
-        symbol: 'kWh',
-    },
-    {
-        name: ['Megawatt hour', 'Megawatt uur'],
-        symbol: 'MWh',
-    },
-    {
-        name: ['Gigawatt hour', 'Gigawatt uur'],
-        symbol: 'GWh',
-    },
-    {
-        name: ['Terawatt hour', 'Terawatt uur'],
-        symbol: 'TWh',
-    },
-    {
-        name: ['Tonnes of oil-equivalent', 'Ton olie-equivalent'],
-        symbol: 'toe',
-    },
-    {
-        name: ['CO2-equivalent in kilotonnes', 'CO2-equivalent in kiloton'],
-        symbol: 'ktCo2',
-    },
+    ...weightUnitOfMeasurements,
+    ...distanceUnitOfMeasurements,
+    ...surfaceUnitOfMeasurements,
+    ...durationUnitOfMeasurements,
+    ...energyUnitOfMeasurements,
+    ...pressureUnitOfMeasurements,
+    ...intensityUnitOfMeasurements,
+    ...speedUnitOfMeasurements,
+    ...temperatureUnitOfMeasurements,
+    ...volumeUnitOfMeasurements,
+    ...volumePercentageUnitOfMeasurements,
+    ...concentrationUnitOfMeasurements,
+    ...densityUnitOfMeasurements,
+    ...digitalUnitOfMeasurement,
+    ...frequencyUnitOfMeasurement,
+    ...percentageUnitOfMeasurements,
 ];

--- a/src/app/model/bodies/unitOfMeasurements.ts
+++ b/src/app/model/bodies/unitOfMeasurements.ts
@@ -1,0 +1,149 @@
+export const unitOfMeasurementTypes = [
+    {
+        name: 'Gram',
+        symbol: 'g',
+    },
+];
+
+export const weightUnitOfMeasurements = [
+    {
+        name: ['Gram', 'Gram'],
+        symbol: 'g',
+    },
+    {
+        name: ['Kilogram', 'Kilogram'],
+        symbol: 'kg',
+    },
+    {
+        name: ['Ton', 'Ton'],
+        symbol: 't',
+    },
+    {
+        name: ['Ounce', 'Ons'],
+        symbol: 'oz',
+    },
+    {
+        name: ['Pound', 'Pond'],
+        symbol: 'lb',
+    },
+];
+
+export const distanceUnitOfMeasurements = [
+    {
+        name: ['Millimetre', 'Millimeter'],
+        symbol: 'mm',
+    },
+    {
+        name: ['Centimetre', 'Centimeter'],
+        symbol: 'cm',
+    },
+    {
+        name: ['metre', 'Meter'],
+        symbol: 'm',
+    },
+    {
+        name: ['Kilometre', 'Kilometer'],
+        symbol: 'km',
+    },
+    {
+        name: ['Inch', 'Inch'],
+        symbol: 'in',
+    },
+    {
+        name: ['Feet', 'Voet'],
+        symbol: 'ft',
+    },
+    {
+        name: ['Mile', 'Mijl'],
+        symbol: 'mi',
+    },
+];
+
+export const surfaceUnitOfMeasurements = [
+    {
+        name: ['Square millimetre', 'Vierkante millimeter'],
+        symbol: 'mm2',
+    },
+    {
+        name: ['Square centimetre', 'Vierkante centimeter'],
+        symbol: 'cm2',
+    },
+    {
+        name: ['Square metre', 'Vierkante meter'],
+        symbol: 'm2',
+    },
+    {
+        name: ['Square kilometre', 'Vierkante kilometer'],
+        symbol: 'km2',
+    },
+    {
+        name: ['Hectare', 'Hectare'],
+        symbol: 'ha',
+    },
+    {
+        name: ['Square feet', 'Vierkante voet'],
+        symbol: 'sqft',
+    },
+    {
+        name: ['Acre', 'Acre'],
+        symbol: 'acre',
+    },
+];
+
+export const durationUnitOfMeasurements = [
+    {
+        name: ['Seconds', 'Seconden'],
+        symbol: 's',
+    },
+    {
+        name: ['Minutes', 'Minuten'],
+        symbol: 'm',
+    },
+    {
+        name: ['Hours', 'Uren'],
+        symbol: 'h',
+    },
+    {
+        name: ['Days', 'Dagen'],
+        symbol: 'd',
+    },
+    {
+        name: ['Months', 'Maanden'],
+        symbol: 'm',
+    },
+    {
+        name: ['Years', 'Jaren'],
+        symbol: 'y',
+    },
+];
+
+export const energyUnitOfMeasurements = [
+    {
+        name: ['Watt hour', 'Watt uur'],
+        symbol: 'Wh',
+    },
+    {
+        name: ['Kilowatt hour', 'Kilowatt uur'],
+        symbol: 'kWh',
+    },
+    {
+        name: ['Megawatt hour', 'Megawatt uur'],
+        symbol: 'MWh',
+    },
+    {
+        name: ['Gigawatt hour', 'Gigawatt uur'],
+        symbol: 'GWh',
+    },
+    {
+        name: ['Terawatt hour', 'Terawatt uur'],
+        symbol: 'TWh',
+    },
+    {
+        name: ['Tonnes of oil-equivalent', 'Ton olie-equivalent'],
+        symbol: 'toe',
+    },
+    {
+        name: ['CO2-equivalent in kilotonnes', 'CO2-equivalent in kiloton'],
+        symbol: 'ktCo2',
+    },
+];

--- a/src/app/model/bodies/unitOfMeasurements.ts
+++ b/src/app/model/bodies/unitOfMeasurements.ts
@@ -158,36 +158,36 @@ const pressureUnitOfMeasurements = [
 
 const intensityUnitOfMeasurements = [
     {
-        name: $localize`:@@uof.decibel.name:Decibel`,
-        symbol: $localize`:@@uof.decibel.symbol:db`,
+        name: $localize`:@@uof.db.name:Decibel`, // Default decibel
+        symbol: $localize`:@@uof.db.symbol:db`,
     },
     {
-        name: $localize`:@@uof.decibela.name:Decibel`,
-        symbol: $localize`:@@uof.decibela.symbol:db(A)`,
+        name: $localize`:@@uof.dba.name:Decibel`, // Corrected db for human ear
+        symbol: $localize`:@@uof.dba.symbol:db(A)`,
     },
     {
-        name: $localize`:@@uof.decibelb.name:Decibel`,
-        symbol: $localize`:@@uof.decibelb.symbol:db(B)`,
+        name: $localize`:@@uof.dbb.name:Decibel`, // Decibel filter b
+        symbol: $localize`:@@uof.dbb.symbol:db(B)`,
     },
     {
-        name: $localize`:@@uof.decibelc.name:Decibel`,
-        symbol: $localize`:@@uof.decibelc.symbol:db(C)`,
+        name: $localize`:@@uof.dbc.name:Decibel`, // Decibel filter c
+        symbol: $localize`:@@uof.dbc.symbol:db(C)`,
     },
     {
         name: $localize`:@@uof.watt.name:Watt`,
         symbol: $localize`:@@uof.watt.symbol:W`,
     },
     {
-        name: $localize`:@@uof.kilowatt.name:Kilowatt`,
-        symbol: $localize`:@@uof.kilowatt.symbol:kW`,
+        name: $localize`:@@uof.kw.name:Kilowatt`,
+        symbol: $localize`:@@uof.kw.symbol:kW`,
     },
     {
-        name: $localize`:@@uof.megawatt.name:Megawatt`,
-        symbol: $localize`:@@uof.megawatt.symbol:MW`,
+        name: $localize`:@@uof.mw.name:Megawatt`,
+        symbol: $localize`:@@uof.mw.symbol:MW`,
     },
     {
-        name: $localize`:@@uof.gigawatt.name:Gigawatt`,
-        symbol: $localize`:@@uof.gigawatt.symbol:GW`,
+        name: $localize`:@@uof.gw.name:Gigawatt`,
+        symbol: $localize`:@@uof.gw.symbol:GW`,
     },
     {
         name: $localize`:@@uof.kva.name:Kilovolt-Ampère`,
@@ -202,8 +202,8 @@ const intensityUnitOfMeasurements = [
         symbol: $localize`:@@uof.volt.symbol:V`,
     },
     {
-        name: $localize`:@@uof.kilovolt.name:Kilovolt`,
-        symbol: $localize`:@@uof.kilovolt.symbol:kV`,
+        name: $localize`:@@uof.kv.name:Kilovolt`,
+        symbol: $localize`:@@uof.kv.symbol:kV`,
     },
 ];
 

--- a/src/i18n/messages.en.xlf
+++ b/src/i18n/messages.en.xlf
@@ -1462,38 +1462,56 @@
       <segment state="final">
         <source>Pa</source>
       <target>Pa</target></segment>
-    </unit><unit id="uof.decibel.name">
+    </unit><unit id="uof.db.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:161</note>
-        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:165</note>
-        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:169</note>
-        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:173</note>
       </notes>
       <segment state="final">
         <source>Decibel</source>
       <target>Decibel</target></segment>
-    </unit><unit id="uof.decibel.symbol">
+    </unit><unit id="uof.db.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:162</note>
       </notes>
       <segment state="final">
         <source>db</source>
       <target>db</target></segment>
-    </unit><unit id="uof.decibela.symbol">
+    </unit><unit id="uof.dba.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:165</note>
+      </notes>
+      <segment state="final">
+        <source>Decibel</source>
+      <target>Decibel</target></segment>
+    </unit><unit id="uof.dba.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:166</note>
       </notes>
       <segment state="final">
         <source>db(A)</source>
       <target>db(A)</target></segment>
-    </unit><unit id="uof.decibelb.symbol">
+    </unit><unit id="uof.dbb.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:169</note>
+      </notes>
+      <segment state="final">
+        <source>Decibel</source>
+      <target>Decibel</target></segment>
+    </unit><unit id="uof.dbb.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:170</note>
       </notes>
       <segment state="final">
         <source>db(B)</source>
       <target>db(B)</target></segment>
-    </unit><unit id="uof.decibelc.symbol">
+    </unit><unit id="uof.dbc.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:173</note>
+      </notes>
+      <segment state="final">
+        <source>Decibel</source>
+      <target>Decibel</target></segment>
+    </unit><unit id="uof.dbc.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:174</note>
       </notes>
@@ -1514,42 +1532,42 @@
       <segment state="final">
         <source>W</source>
       <target>W</target></segment>
-    </unit><unit id="uof.kilowatt.name">
+    </unit><unit id="uof.kw.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:181</note>
       </notes>
       <segment state="final">
         <source>Kilowatt</source>
       <target>Kilowatt</target></segment>
-    </unit><unit id="uof.kilowatt.symbol">
+    </unit><unit id="uof.kw.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:182</note>
       </notes>
       <segment state="final">
         <source>kW</source>
       <target>kW</target></segment>
-    </unit><unit id="uof.megawatt.name">
+    </unit><unit id="uof.mw.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:185</note>
       </notes>
       <segment state="final">
         <source>Megawatt</source>
       <target>Megawatt</target></segment>
-    </unit><unit id="uof.megawatt.symbol">
+    </unit><unit id="uof.mw.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:186</note>
       </notes>
       <segment state="final">
         <source>MW</source>
       <target>MW</target></segment>
-    </unit><unit id="uof.gigawatt.name">
+    </unit><unit id="uof.gw.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:189</note>
       </notes>
       <segment state="final">
         <source>Gigawatt</source>
       <target>Gigawatt</target></segment>
-    </unit><unit id="uof.gigawatt.symbol">
+    </unit><unit id="uof.gw.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:190</note>
       </notes>
@@ -1570,14 +1588,14 @@
       <segment state="final">
         <source>kVA</source>
       <target>kVA</target></segment>
-    </unit><unit id="uof.kA.name">
+    </unit><unit id="uof.ka.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:197</note>
       </notes>
       <segment state="final">
         <source>Ampère</source>
       <target>Ampère</target></segment>
-    </unit><unit id="uof.kA.symbol">
+    </unit><unit id="uof.ka.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:198</note>
       </notes>
@@ -1598,14 +1616,14 @@
       <segment state="final">
         <source>V</source>
       <target>V</target></segment>
-    </unit><unit id="uof.kilovolt.name">
+    </unit><unit id="uof.kv.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:205</note>
       </notes>
       <segment state="final">
         <source>Kilovolt</source>
       <target>Kilovolt</target></segment>
-    </unit><unit id="uof.kilovolt.symbol">
+    </unit><unit id="uof.kv.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:206</note>
       </notes>

--- a/src/i18n/messages.en.xlf
+++ b/src/i18n/messages.en.xlf
@@ -334,6 +334,20 @@
       <segment state="final">
         <source>Organization Details</source>
       <target>Organization Details</target></segment>
+    </unit><unit id="1367870144394891892">
+      <notes>
+        <note category="location">src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.html:5</note>
+      </notes>
+      <segment state="final">
+        <source>Enter Name</source>
+      <target>Enter Name</target></segment>
+    </unit><unit id="8887635712969424708">
+      <notes>
+        <note category="location">src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.html:10</note>
+      </notes>
+      <segment state="final">
+        <source>Enter Symbol</source>
+      <target>Enter Symbol</target></segment>
     </unit><unit id="3797778920049399855">
       <notes>
         
@@ -591,7 +605,7 @@
       <notes>
 
 
-      <note category="location">src/app/form-controls/datastream/datastream.component.html:75</note><note category="location">src/app/form-controls/sensor/sensor.component.html:40</note></notes>
+      <note category="location">src/app/form-controls/datastream/datastream.component.html:79</note><note category="location">src/app/form-controls/sensor/sensor.component.html:40</note></notes>
       <segment state="final">
         <source>Enter URL of documentation</source>
       <target>Enter URL of documentation</target></segment>
@@ -645,7 +659,7 @@
 
 
 
-      <note category="location">src/app/components/observation-goal/observation-goal.component.html:41</note><note category="location">src/app/form-controls/datastream/datastream.component.html:79</note><note category="location">src/app/form-controls/datastream/datastream.component.html:88</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:12</note><note category="location">src/app/form-controls/sensor/sensor.component.html:44</note></notes>
+      <note category="location">src/app/components/observation-goal/observation-goal.component.html:41</note><note category="location">src/app/form-controls/datastream/datastream.component.html:83</note><note category="location">src/app/form-controls/datastream/datastream.component.html:92</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:12</note><note category="location">src/app/form-controls/sensor/sensor.component.html:44</note></notes>
       <segment state="final">
         <source>Not a valid URL</source>
       <target>Not a valid URL</target></segment>
@@ -820,7 +834,7 @@
     </unit><unit id="8254163730790501097">
       <notes>
 
-      <note category="location">src/app/components/observation-goal/observation-goal.component.html:33</note><note category="location">src/app/components/observation-goal/observation-goal.component.html:38</note><note category="location">src/app/form-controls/datastream/datastream.component.html:4</note><note category="location">src/app/form-controls/datastream/datastream.component.html:30</note><note category="location">src/app/form-controls/datastream/datastream.component.html:37</note><note category="location">src/app/form-controls/datastream/datastream.component.html:74</note><note category="location">src/app/form-controls/datastream/datastream.component.html:83</note><note category="location">src/app/form-controls/datastream/datastream.component.html:92</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:9</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:16</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:21</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:32</note><note category="location">src/app/form-controls/sensor/sensor.component.html:3</note><note category="location">src/app/form-controls/sensor/sensor.component.html:31</note><note category="location">src/app/form-controls/sensor/sensor.component.html:35</note><note category="location">src/app/form-controls/sensor/sensor.component.html:39</note><note category="location">src/app/form-controls/theme/theme.component.html:2</note><note category="location">src/app/forms/device/device.component.html:37</note><note category="location">src/app/forms/device/device.component.html:41</note><note category="location">src/app/forms/device/device.component.html:46</note><note category="location">src/app/forms/device/device.component.html:50</note></notes>
+      <note category="location">src/app/components/observation-goal/observation-goal.component.html:33</note><note category="location">src/app/components/observation-goal/observation-goal.component.html:38</note><note category="location">src/app/form-controls/datastream/datastream.component.html:4</note><note category="location">src/app/form-controls/datastream/datastream.component.html:30</note><note category="location">src/app/form-controls/datastream/datastream.component.html:37</note><note category="location">src/app/form-controls/datastream/datastream.component.html:74</note><note category="location">src/app/form-controls/datastream/datastream.component.html:78</note><note category="location">src/app/form-controls/datastream/datastream.component.html:87</note><note category="location">src/app/form-controls/datastream/datastream.component.html:96</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:9</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:16</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:21</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:32</note><note category="location">src/app/form-controls/sensor/sensor.component.html:3</note><note category="location">src/app/form-controls/sensor/sensor.component.html:31</note><note category="location">src/app/form-controls/sensor/sensor.component.html:35</note><note category="location">src/app/form-controls/sensor/sensor.component.html:39</note><note category="location">src/app/form-controls/theme/theme.component.html:2</note><note category="location">src/app/forms/device/device.component.html:37</note><note category="location">src/app/forms/device/device.component.html:41</note><note category="location">src/app/forms/device/device.component.html:46</note><note category="location">src/app/forms/device/device.component.html:50</note></notes>
       <segment state="final">
         <source> - Optional</source>
       <target> - Optional</target></segment>
@@ -909,24 +923,31 @@
       <segment state="final">
         <source>Is Reusable</source>
       <target>Is Reusable</target></segment>
+    </unit><unit id="1752037547151431451">
+      <notes>
+        <note category="location">src/app/form-controls/datastream/datastream.component.html:74</note>
+      </notes>
+      <segment state="final">
+        <source>Unit Of Measurement</source>
+      <target>Unit Of Measurement</target></segment>
     </unit><unit id="4895326106573044490">
       <notes>
 
-      <note category="location">src/app/form-controls/datastream/datastream.component.html:74</note><note category="location">src/app/form-controls/sensor/sensor.component.html:39</note></notes>
+      <note category="location">src/app/form-controls/datastream/datastream.component.html:78</note><note category="location">src/app/form-controls/sensor/sensor.component.html:39</note></notes>
       <segment state="final">
         <source>Documentation</source>
       <target>Documentation</target></segment>
     </unit><unit id="8732411010010701151">
       <notes>
 
-      <note category="location">src/app/form-controls/datastream/datastream.component.html:83</note></notes>
+      <note category="location">src/app/form-controls/datastream/datastream.component.html:87</note></notes>
       <segment state="final">
         <source>Datalink</source>
       <target>Datalink</target></segment>
     </unit><unit id="3465033560498443683">
       <notes>
 
-      <note category="location">src/app/form-controls/datastream/datastream.component.html:84</note></notes>
+      <note category="location">src/app/form-controls/datastream/datastream.component.html:88</note></notes>
       <segment state="final">
         <source>Enter URL of data</source>
       <target>Enter URL of data</target></segment>
@@ -951,6 +972,1150 @@
       <segment state="final">
         <source>Camera</source>
       <target>Camera</target></segment>
+    </unit><unit id="uof.gram.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:3</note>
+      </notes>
+      <segment state="final">
+        <source>Gram</source>
+      <target>Gram</target></segment>
+    </unit><unit id="uof.gram.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:4</note>
+      </notes>
+      <segment state="final">
+        <source>g</source>
+      <target>g</target></segment>
+    </unit><unit id="uof.kilogram.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:7</note>
+      </notes>
+      <segment state="final">
+        <source>Kilogram</source>
+      <target>Kilogram</target></segment>
+    </unit><unit id="uof.kilogram.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:8</note>
+      </notes>
+      <segment state="final">
+        <source>kg</source>
+      <target>kg</target></segment>
+    </unit><unit id="uof.ton.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:11</note>
+      </notes>
+      <segment state="final">
+        <source>Tonne</source>
+      <target>Tonne</target></segment>
+    </unit><unit id="uof.ton.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:12</note>
+      </notes>
+      <segment state="final">
+        <source>t</source>
+      <target>t</target></segment>
+    </unit><unit id="uof.ounce.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:15</note>
+      </notes>
+      <segment state="final">
+        <source>Ounce</source>
+      <target>Ounce</target></segment>
+    </unit><unit id="uof.ounce.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:16</note>
+      </notes>
+      <segment state="final">
+        <source>oz</source>
+      <target>oz</target></segment>
+    </unit><unit id="uof.pound.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:19</note>
+      </notes>
+      <segment state="final">
+        <source>Pound</source>
+      <target>Pound</target></segment>
+    </unit><unit id="uof.pound.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:20</note>
+      </notes>
+      <segment state="final">
+        <source>lb</source>
+      <target>lb</target></segment>
+    </unit><unit id="uof.millimeter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:26</note>
+      </notes>
+      <segment state="final">
+        <source>Millimeter</source>
+      <target>Millimeter</target></segment>
+    </unit><unit id="uof.millimeter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:27</note>
+      </notes>
+      <segment state="final">
+        <source>mm</source>
+      <target>mm</target></segment>
+    </unit><unit id="uof.centimeter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:30</note>
+      </notes>
+      <segment state="final">
+        <source>Centimeter</source>
+      <target>Centimeter</target></segment>
+    </unit><unit id="uof.centimeter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:31</note>
+      </notes>
+      <segment state="final">
+        <source>cm</source>
+      <target>cm</target></segment>
+    </unit><unit id="uof.meter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:34</note>
+      </notes>
+      <segment state="final">
+        <source>Meter</source>
+      <target>Meter</target></segment>
+    </unit><unit id="uof.meter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:35</note>
+      </notes>
+      <segment state="final">
+        <source>m</source>
+      <target>m</target></segment>
+    </unit><unit id="uof.kilometer.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:38</note>
+      </notes>
+      <segment state="final">
+        <source>Kilometer</source>
+      <target>Kilometer</target></segment>
+    </unit><unit id="uof.kilometer.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:39</note>
+      </notes>
+      <segment state="final">
+        <source>km</source>
+      <target>km</target></segment>
+    </unit><unit id="uof.inch.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:42</note>
+      </notes>
+      <segment state="final">
+        <source>Inch</source>
+      <target>Inch</target></segment>
+    </unit><unit id="uof.inch.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:43</note>
+      </notes>
+      <segment state="final">
+        <source>in</source>
+      <target>in</target></segment>
+    </unit><unit id="uof.feet.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:46</note>
+      </notes>
+      <segment state="final">
+        <source>Feet</source>
+      <target>Feet</target></segment>
+    </unit><unit id="uof.ft.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:47</note>
+      </notes>
+      <segment state="final">
+        <source>ft</source>
+      <target>ft</target></segment>
+    </unit><unit id="uof.mile.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:50</note>
+      </notes>
+      <segment state="final">
+        <source>Mile</source>
+      <target>Mile</target></segment>
+    </unit><unit id="uof.mile.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:51</note>
+      </notes>
+      <segment state="final">
+        <source>mi</source>
+      <target>mi</target></segment>
+    </unit><unit id="uof.mm2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:57</note>
+      </notes>
+      <segment state="final">
+        <source>Square millimeter</source>
+      <target>Square millimeter</target></segment>
+    </unit><unit id="uof.mm2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:58</note>
+      </notes>
+      <segment state="final">
+        <source>mm2</source>
+      <target>mm2</target></segment>
+    </unit><unit id="uof.cm2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:61</note>
+      </notes>
+      <segment state="final">
+        <source>Square centimeter</source>
+      <target>Square centimeter</target></segment>
+    </unit><unit id="uof.cm2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:62</note>
+      </notes>
+      <segment state="final">
+        <source>cm2</source>
+      <target>cm2</target></segment>
+    </unit><unit id="uof.m2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:65</note>
+      </notes>
+      <segment state="final">
+        <source>Square meter</source>
+      <target>Square meter</target></segment>
+    </unit><unit id="uof.m2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:66</note>
+      </notes>
+      <segment state="final">
+        <source>m2</source>
+      <target>m2</target></segment>
+    </unit><unit id="uof.km2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:69</note>
+      </notes>
+      <segment state="final">
+        <source>Square kilometer</source>
+      <target>Square kilometer</target></segment>
+    </unit><unit id="uof.km2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:70</note>
+      </notes>
+      <segment state="final">
+        <source>km2</source>
+      <target>km2</target></segment>
+    </unit><unit id="uof.hectare.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:73</note>
+      </notes>
+      <segment state="final">
+        <source>Hectare</source>
+      <target>Hectare</target></segment>
+    </unit><unit id="uof.hectare.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:74</note>
+      </notes>
+      <segment state="final">
+        <source>ha</source>
+      <target>ha</target></segment>
+    </unit><unit id="uof.sqft.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:77</note>
+      </notes>
+      <segment state="final">
+        <source>Square feet</source>
+      <target>Square feet</target></segment>
+    </unit><unit id="uof.sqft.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:78</note>
+      </notes>
+      <segment state="final">
+        <source>sqft</source>
+      <target>sqft</target></segment>
+    </unit><unit id="uof.acre.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:81</note>
+      </notes>
+      <segment state="final">
+        <source>Acre</source>
+      <target>Acre</target></segment>
+    </unit><unit id="uof.acre.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:82</note>
+      </notes>
+      <segment state="final">
+        <source>acre</source>
+      <target>acre</target></segment>
+    </unit><unit id="uof.seconds.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:88</note>
+      </notes>
+      <segment state="final">
+        <source>Seconds</source>
+      <target>Seconds</target></segment>
+    </unit><unit id="uof.seconds.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:89</note>
+      </notes>
+      <segment state="final">
+        <source>s</source>
+      <target>s</target></segment>
+    </unit><unit id="uof.minutes.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:92</note>
+      </notes>
+      <segment state="final">
+        <source>Minutes</source>
+      <target>Minutes</target></segment>
+    </unit><unit id="uof.minutes.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:93</note>
+      </notes>
+      <segment state="final">
+        <source>m</source>
+      <target>m</target></segment>
+    </unit><unit id="uof.hours.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:96</note>
+      </notes>
+      <segment state="final">
+        <source>Hours</source>
+      <target>Hours</target></segment>
+    </unit><unit id="uof.hours.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:97</note>
+      </notes>
+      <segment state="final">
+        <source>h</source>
+      <target>h</target></segment>
+    </unit><unit id="uof.days.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:100</note>
+      </notes>
+      <segment state="final">
+        <source>Days</source>
+      <target>Days</target></segment>
+    </unit><unit id="uof.days.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:101</note>
+      </notes>
+      <segment state="final">
+        <source>d</source>
+      <target>d</target></segment>
+    </unit><unit id="uof.months.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:104</note>
+      </notes>
+      <segment state="final">
+        <source>Months</source>
+      <target>Months</target></segment>
+    </unit><unit id="uof.months.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:105</note>
+      </notes>
+      <segment state="final">
+        <source>m</source>
+      <target>m</target></segment>
+    </unit><unit id="uof.years.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:108</note>
+      </notes>
+      <segment state="final">
+        <source>Years</source>
+      <target>Years</target></segment>
+    </unit><unit id="uof.years.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:109</note>
+      </notes>
+      <segment state="final">
+        <source>y</source>
+      <target>y</target></segment>
+    </unit><unit id="uof.wh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:115</note>
+      </notes>
+      <segment state="final">
+        <source>Watt hour</source>
+      <target>Watt hour</target></segment>
+    </unit><unit id="uof.wh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:116</note>
+      </notes>
+      <segment state="final">
+        <source>Wh</source>
+      <target>Wh</target></segment>
+    </unit><unit id="uof.kwh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:119</note>
+      </notes>
+      <segment state="final">
+        <source>Kilowatt hour</source>
+      <target>Kilowatt hour</target></segment>
+    </unit><unit id="uof.kwh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:120</note>
+      </notes>
+      <segment state="final">
+        <source>kWh</source>
+      <target>kWh</target></segment>
+    </unit><unit id="uof.mwh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:123</note>
+      </notes>
+      <segment state="final">
+        <source>Megawatt hour</source>
+      <target>Megawatt hour</target></segment>
+    </unit><unit id="uof.mwh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:124</note>
+      </notes>
+      <segment state="final">
+        <source>MWh</source>
+      <target>MWh</target></segment>
+    </unit><unit id="uof.gwh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:127</note>
+      </notes>
+      <segment state="final">
+        <source>Gigawatt hour</source>
+      <target>Gigawatt hour</target></segment>
+    </unit><unit id="uof.gwh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:128</note>
+      </notes>
+      <segment state="final">
+        <source>GWh</source>
+      <target>GWh</target></segment>
+    </unit><unit id="uof.twh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:131</note>
+      </notes>
+      <segment state="final">
+        <source>Terawatt hour</source>
+      <target>Terawatt hour</target></segment>
+    </unit><unit id="uof.twh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:132</note>
+      </notes>
+      <segment state="final">
+        <source>TWh</source>
+      <target>TWh</target></segment>
+    </unit><unit id="uof.toe.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:135</note>
+      </notes>
+      <segment state="final">
+        <source>Tonnes of oil-equivalent</source>
+      <target>Tonnes of oil-equivalent</target></segment>
+    </unit><unit id="uof.toe.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:136</note>
+      </notes>
+      <segment state="final">
+        <source>toe</source>
+      <target>toe</target></segment>
+    </unit><unit id="uof.ktCo2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:139</note>
+      </notes>
+      <segment state="final">
+        <source>CO2-equivalent in kilotonnes</source>
+      <target>CO2-equivalent in kilotonnes</target></segment>
+    </unit><unit id="uof.ktCo2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:140</note>
+      </notes>
+      <segment state="final">
+        <source>ktCo2</source>
+      <target>ktCo2</target></segment>
+    </unit><unit id="uof.bar.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:146</note>
+      </notes>
+      <segment state="final">
+        <source>Bar</source>
+      <target>Bar</target></segment>
+    </unit><unit id="uof.bar.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:147</note>
+      </notes>
+      <segment state="final">
+        <source>bar</source>
+      <target>bar</target></segment>
+    </unit><unit id="uof.mbar.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:150</note>
+      </notes>
+      <segment state="final">
+        <source>Millibar</source>
+      <target>Millibar</target></segment>
+    </unit><unit id="uof.mbar.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:151</note>
+      </notes>
+      <segment state="final">
+        <source>mbar</source>
+      <target>mbar</target></segment>
+    </unit><unit id="uof.pascal.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:154</note>
+      </notes>
+      <segment state="final">
+        <source>Pascal</source>
+      <target>Pascal</target></segment>
+    </unit><unit id="uof.pascal.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:155</note>
+      </notes>
+      <segment state="final">
+        <source>Pa</source>
+      <target>Pa</target></segment>
+    </unit><unit id="uof.decibel.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:161</note>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:165</note>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:169</note>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:173</note>
+      </notes>
+      <segment state="final">
+        <source>Decibel</source>
+      <target>Decibel</target></segment>
+    </unit><unit id="uof.decibel.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:162</note>
+      </notes>
+      <segment state="final">
+        <source>db</source>
+      <target>db</target></segment>
+    </unit><unit id="uof.decibela.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:166</note>
+      </notes>
+      <segment state="final">
+        <source>db(A)</source>
+      <target>db(A)</target></segment>
+    </unit><unit id="uof.decibelb.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:170</note>
+      </notes>
+      <segment state="final">
+        <source>db(B)</source>
+      <target>db(B)</target></segment>
+    </unit><unit id="uof.decibelc.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:174</note>
+      </notes>
+      <segment state="final">
+        <source>db(C)</source>
+      <target>db(C)</target></segment>
+    </unit><unit id="uof.watt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:177</note>
+      </notes>
+      <segment state="final">
+        <source>Watt</source>
+      <target>Watt</target></segment>
+    </unit><unit id="uof.watt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:178</note>
+      </notes>
+      <segment state="final">
+        <source>W</source>
+      <target>W</target></segment>
+    </unit><unit id="uof.kilowatt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:181</note>
+      </notes>
+      <segment state="final">
+        <source>Kilowatt</source>
+      <target>Kilowatt</target></segment>
+    </unit><unit id="uof.kilowatt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:182</note>
+      </notes>
+      <segment state="final">
+        <source>kW</source>
+      <target>kW</target></segment>
+    </unit><unit id="uof.megawatt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:185</note>
+      </notes>
+      <segment state="final">
+        <source>Megawatt</source>
+      <target>Megawatt</target></segment>
+    </unit><unit id="uof.megawatt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:186</note>
+      </notes>
+      <segment state="final">
+        <source>MW</source>
+      <target>MW</target></segment>
+    </unit><unit id="uof.gigawatt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:189</note>
+      </notes>
+      <segment state="final">
+        <source>Gigawatt</source>
+      <target>Gigawatt</target></segment>
+    </unit><unit id="uof.gigawatt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:190</note>
+      </notes>
+      <segment state="final">
+        <source>GW</source>
+      <target>GW</target></segment>
+    </unit><unit id="uof.kva.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:193</note>
+      </notes>
+      <segment state="final">
+        <source>Kilovolt-Ampère</source>
+      <target>Kilovolt-Ampère</target></segment>
+    </unit><unit id="uof.kva.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:194</note>
+      </notes>
+      <segment state="final">
+        <source>kVA</source>
+      <target>kVA</target></segment>
+    </unit><unit id="uof.kA.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:197</note>
+      </notes>
+      <segment state="final">
+        <source>Ampère</source>
+      <target>Ampère</target></segment>
+    </unit><unit id="uof.kA.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:198</note>
+      </notes>
+      <segment state="final">
+        <source>kA</source>
+      <target>kA</target></segment>
+    </unit><unit id="uof.volt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:201</note>
+      </notes>
+      <segment state="final">
+        <source>Volt</source>
+      <target>Volt</target></segment>
+    </unit><unit id="uof.volt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:202</note>
+      </notes>
+      <segment state="final">
+        <source>V</source>
+      <target>V</target></segment>
+    </unit><unit id="uof.kilovolt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:205</note>
+      </notes>
+      <segment state="final">
+        <source>Kilovolt</source>
+      <target>Kilovolt</target></segment>
+    </unit><unit id="uof.kilovolt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:206</note>
+      </notes>
+      <segment state="final">
+        <source>kV</source>
+      <target>kV</target></segment>
+    </unit><unit id="uof.mps.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:212</note>
+      </notes>
+      <segment state="final">
+        <source>Meters per second</source>
+      <target>Meters per second</target></segment>
+    </unit><unit id="uof.mps.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:213</note>
+      </notes>
+      <segment state="final">
+        <source>m/s</source>
+      <target>m/s</target></segment>
+    </unit><unit id="uof.kmps.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:216</note>
+      </notes>
+      <segment state="final">
+        <source>Kilometers per second</source>
+      <target>Kilometers per second</target></segment>
+    </unit><unit id="uof.kmps.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:217</note>
+      </notes>
+      <segment state="final">
+        <source>km/s</source>
+      <target>km/s</target></segment>
+    </unit><unit id="uof.kmph.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:220</note>
+      </notes>
+      <segment state="final">
+        <source>Kilometers per hour</source>
+      <target>Kilometers per hour</target></segment>
+    </unit><unit id="uof.kmph.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:221</note>
+      </notes>
+      <segment state="final">
+        <source>km/h</source>
+      <target>km/h</target></segment>
+    </unit><unit id="uof.mph.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:224</note>
+      </notes>
+      <segment state="final">
+        <source>Mile per hour</source>
+      <target>Mile per hour</target></segment>
+    </unit><unit id="uof.mph.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:225</note>
+      </notes>
+      <segment state="final">
+        <source>mph</source>
+      <target>mph</target></segment>
+    </unit><unit id="uof.celcius.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:231</note>
+      </notes>
+      <segment state="final">
+        <source>Celsius</source>
+      <target>Celsius</target></segment>
+    </unit><unit id="uof.celcius.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:232</note>
+      </notes>
+      <segment state="final">
+        <source>C</source>
+      <target>C</target></segment>
+    </unit><unit id="uof.fahrenheit.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:235</note>
+      </notes>
+      <segment state="final">
+        <source>Fahrenheit</source>
+      <target>Fahrenheit</target></segment>
+    </unit><unit id="uof.fahrenheit.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:236</note>
+      </notes>
+      <segment state="final">
+        <source>F</source>
+      <target>F</target></segment>
+    </unit><unit id="uof.kelvin.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:239</note>
+      </notes>
+      <segment state="final">
+        <source>Kelvin</source>
+      <target>Kelvin</target></segment>
+    </unit><unit id="uof.kelvin.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:240</note>
+      </notes>
+      <segment state="final">
+        <source>K</source>
+      <target>K</target></segment>
+    </unit><unit id="uof.cm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:246</note>
+      </notes>
+      <segment state="final">
+        <source>Cubic centimeter</source>
+      <target>Cubic centimeter</target></segment>
+    </unit><unit id="uof.cm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:247</note>
+      </notes>
+      <segment state="final">
+        <source>cm3</source>
+      <target>cm3</target></segment>
+    </unit><unit id="uof.dm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:250</note>
+      </notes>
+      <segment state="final">
+        <source>Cubic decimeter</source>
+      <target>Cubic decimeter</target></segment>
+    </unit><unit id="uof.dm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:251</note>
+      </notes>
+      <segment state="final">
+        <source>dm3</source>
+      <target>dm3</target></segment>
+    </unit><unit id="uof.m3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:254</note>
+      </notes>
+      <segment state="final">
+        <source>Cubic meter</source>
+      <target>Cubic meter</target></segment>
+    </unit><unit id="uof.m3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:255</note>
+      </notes>
+      <segment state="final">
+        <source>m3</source>
+      <target>m3</target></segment>
+    </unit><unit id="uof.liter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:258</note>
+      </notes>
+      <segment state="final">
+        <source>Liter</source>
+      <target>Liter</target></segment>
+    </unit><unit id="uof.liter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:259</note>
+      </notes>
+      <segment state="final">
+        <source>L</source>
+      <target>L</target></segment>
+    </unit><unit id="uof.hectoliter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:262</note>
+      </notes>
+      <segment state="final">
+        <source>Hectoliter</source>
+      <target>Hectoliter</target></segment>
+    </unit><unit id="uof.hectoliter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:263</note>
+      </notes>
+      <segment state="final">
+        <source>hL</source>
+      <target>hL</target></segment>
+    </unit><unit id="uof.hm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:266</note>
+      </notes>
+      <segment state="final">
+        <source>Cubic hectometer</source>
+      <target>Cubic hectometer</target></segment>
+    </unit><unit id="uof.hm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:267</note>
+      </notes>
+      <segment state="final">
+        <source>hm3</source>
+      <target>hm3</target></segment>
+    </unit><unit id="uof.m3s.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:273</note>
+      </notes>
+      <segment state="final">
+        <source>Cubic meter per second</source>
+      <target>Cubic meter per second</target></segment>
+    </unit><unit id="uof.m3s.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:274</note>
+      </notes>
+      <segment state="final">
+        <source>m3/s</source>
+      <target>m3/s</target></segment>
+    </unit><unit id="uof.Ls.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:277</note>
+      </notes>
+      <segment state="final">
+        <source>Liter per second</source>
+      <target>Liter per second</target></segment>
+    </unit><unit id="uof.Ls.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:278</note>
+      </notes>
+      <segment state="final">
+        <source>L/s</source>
+      <target>L/s</target></segment>
+    </unit><unit id="uof.m3h.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:281</note>
+      </notes>
+      <segment state="final">
+        <source>Cubic meter per hour</source>
+      <target>Cubic meter per hour</target></segment>
+    </unit><unit id="uof.m3h.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:282</note>
+      </notes>
+      <segment state="final">
+        <source>m3/h</source>
+      <target>m3/h</target></segment>
+    </unit><unit id="uof.Lh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:285</note>
+      </notes>
+      <segment state="final">
+        <source>Liter per hour</source>
+      <target>Liter per hour</target></segment>
+    </unit><unit id="uof.Lh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:286</note>
+      </notes>
+      <segment state="final">
+        <source>L/h</source>
+      <target>L/h</target></segment>
+    </unit><unit id="uof.m3d.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:289</note>
+      </notes>
+      <segment state="final">
+        <source>Cubic meter per day</source>
+      <target>Cubic meter per day</target></segment>
+    </unit><unit id="uof.m3d.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:290</note>
+      </notes>
+      <segment state="final">
+        <source>m3/d</source>
+      <target>m3/d</target></segment>
+    </unit><unit id="uof.Ld.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:293</note>
+      </notes>
+      <segment state="final">
+        <source>Liter per day</source>
+      <target>Liter per day</target></segment>
+    </unit><unit id="uof.Ld.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:294</note>
+      </notes>
+      <segment state="final">
+        <source>L/d</source>
+      <target>L/d</target></segment>
+    </unit><unit id="uof.ppm.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:300</note>
+      </notes>
+      <segment state="final">
+        <source>Part per million</source>
+      <target>Part per million</target></segment>
+    </unit><unit id="uof.ppm.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:301</note>
+      </notes>
+      <segment state="final">
+        <source>ppm</source>
+      <target>ppm</target></segment>
+    </unit><unit id="uof.µgL.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:307</note>
+      </notes>
+      <segment state="final">
+        <source>Microgram per liter</source>
+      <target>Microgram per liter</target></segment>
+    </unit><unit id="uof.µgL.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:308</note>
+      </notes>
+      <segment state="final">
+        <source>µg/L</source>
+      <target>µg/L</target></segment>
+    </unit><unit id="uof.mgL.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:311</note>
+      </notes>
+      <segment state="final">
+        <source>Miligram per liter</source>
+      <target>Miligram per liter</target></segment>
+    </unit><unit id="uof.mgL.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:312</note>
+      </notes>
+      <segment state="final">
+        <source>mg/L</source>
+      <target>mg/L</target></segment>
+    </unit><unit id="uof.µgm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:315</note>
+      </notes>
+      <segment state="final">
+        <source>Microgram per cubic meter</source>
+      <target>Microgram per cubic meter</target></segment>
+    </unit><unit id="uof.µgm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:316</note>
+      </notes>
+      <segment state="final">
+        <source>µ5g/m3</source>
+      <target>µ5g/m3</target></segment>
+    </unit><unit id="uof.mgm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:319</note>
+      </notes>
+      <segment state="final">
+        <source>Milligram per cubic meter</source>
+      <target>Milligram per cubic meter</target></segment>
+    </unit><unit id="uof.mgm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:320</note>
+      </notes>
+      <segment state="final">
+        <source>mg/m3</source>
+      <target>mg/m3</target></segment>
+    </unit><unit id="uof.gL.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:323</note>
+      </notes>
+      <segment state="final">
+        <source>Gram per liter</source>
+      <target>Gram per liter</target></segment>
+    </unit><unit id="uof.gL.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:324</note>
+      </notes>
+      <segment state="final">
+        <source>g/L</source>
+      <target>g/L</target></segment>
+    </unit><unit id="uof.kgm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:327</note>
+      </notes>
+      <segment state="final">
+        <source>Kilogram per cubic meter</source>
+      <target>Kilogram per cubic meter</target></segment>
+    </unit><unit id="uof.kgm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:328</note>
+      </notes>
+      <segment state="final">
+        <source>kg/m3</source>
+      <target>kg/m3</target></segment>
+    </unit><unit id="uof.byte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:334</note>
+      </notes>
+      <segment state="final">
+        <source>Byte</source>
+      <target>Byte</target></segment>
+    </unit><unit id="uof.byte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:335</note>
+      </notes>
+      <segment state="final">
+        <source>B</source>
+      <target>B</target></segment>
+    </unit><unit id="uof.kilobyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:338</note>
+      </notes>
+      <segment state="final">
+        <source>Kilobyte</source>
+      <target>Kilobyte</target></segment>
+    </unit><unit id="uof.kilobyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:339</note>
+      </notes>
+      <segment state="final">
+        <source>kB</source>
+      <target>kB</target></segment>
+    </unit><unit id="uof.megabyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:342</note>
+      </notes>
+      <segment state="final">
+        <source>Megabyte</source>
+      <target>Megabyte</target></segment>
+    </unit><unit id="uof.megabyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:343</note>
+      </notes>
+      <segment state="final">
+        <source>MB</source>
+      <target>MB</target></segment>
+    </unit><unit id="uof.gigabyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:346</note>
+      </notes>
+      <segment state="final">
+        <source>Gigabyte</source>
+      <target>Gigabyte</target></segment>
+    </unit><unit id="uof.gigabyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:347</note>
+      </notes>
+      <segment state="final">
+        <source>GB</source>
+      <target>GB</target></segment>
+    </unit><unit id="uof.terabyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:350</note>
+      </notes>
+      <segment state="final">
+        <source>Terabyte</source>
+      <target>Terabyte</target></segment>
+    </unit><unit id="uof.terabyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:351</note>
+      </notes>
+      <segment state="final">
+        <source>TB</source>
+      <target>TB</target></segment>
+    </unit><unit id="uof.petabyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:354</note>
+      </notes>
+      <segment state="final">
+        <source>Petabyte</source>
+      <target>Petabyte</target></segment>
+    </unit><unit id="uof.petabyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:355</note>
+      </notes>
+      <segment state="final">
+        <source>PB</source>
+      <target>PB</target></segment>
+    </unit><unit id="uof.hertz.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:361</note>
+      </notes>
+      <segment state="final">
+        <source>Hertz</source>
+      <target>Hertz</target></segment>
+    </unit><unit id="uof.hertz.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:362</note>
+      </notes>
+      <segment state="final">
+        <source>Hz</source>
+      <target>Hz</target></segment>
+    </unit><unit id="uof.megahertz.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:365</note>
+      </notes>
+      <segment state="final">
+        <source>Megahertz</source>
+      <target>Megahertz</target></segment>
+    </unit><unit id="uof.megahertz.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:366</note>
+      </notes>
+      <segment state="final">
+        <source>MHz</source>
+      <target>MHz</target></segment>
+    </unit><unit id="uof.gigahertz.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:369</note>
+      </notes>
+      <segment state="final">
+        <source>Gigahertz</source>
+      <target>Gigahertz</target></segment>
+    </unit><unit id="uof.gigahertz.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:370</note>
+      </notes>
+      <segment state="final">
+        <source>GHz</source>
+      <target>GHz</target></segment>
+    </unit><unit id="uof.percentage.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:376</note>
+      </notes>
+      <segment state="final">
+        <source>Percentage</source>
+      <target>Percentage</target></segment>
+    </unit><unit id="uof.percentage.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:377</note>
+      </notes>
+      <segment state="final">
+        <source>%</source>
+      <target>%</target></segment>
     </unit><unit id="8682931004646337355">
       <notes>
         <note category="location">src/app/navbar/navbar.component.html:3,4</note>
@@ -1355,7 +2520,7 @@
 
 
 
-      <note category="location">src/app/form-controls/datastream/datastream.component.html:92</note><note category="location">src/app/sidebar/sidebar.component.html:12</note></notes>
+      <note category="location">src/app/form-controls/datastream/datastream.component.html:96</note><note category="location">src/app/sidebar/sidebar.component.html:12</note></notes>
       <segment state="final">
         <source>Observation Goals</source>
       <target>Observation Goals</target></segment>

--- a/src/i18n/messages.nl.xlf
+++ b/src/i18n/messages.nl.xlf
@@ -1462,38 +1462,56 @@
       <segment state="translated">
         <source>Pa</source>
       <target>Pa</target></segment>
-    </unit><unit id="uof.decibel.name">
+    </unit><unit id="uof.db.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:161</note>
-        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:165</note>
-        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:169</note>
-        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:173</note>
       </notes>
       <segment state="translated">
         <source>Decibel</source>
       <target>Decibel</target></segment>
-    </unit><unit id="uof.decibel.symbol">
+    </unit><unit id="uof.db.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:162</note>
       </notes>
       <segment state="translated">
         <source>db</source>
       <target>db</target></segment>
-    </unit><unit id="uof.decibela.symbol">
+    </unit><unit id="uof.dba.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:165</note>
+      </notes>
+      <segment state="translated">
+        <source>Decibel</source>
+      <target>Decibel</target></segment>
+    </unit><unit id="uof.dba.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:166</note>
       </notes>
       <segment state="translated">
         <source>db(A)</source>
       <target>db(A)</target></segment>
-    </unit><unit id="uof.decibelb.symbol">
+    </unit><unit id="uof.dbb.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:169</note>
+      </notes>
+      <segment state="translated">
+        <source>Decibel</source>
+      <target>Decibel</target></segment>
+    </unit><unit id="uof.dbb.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:170</note>
       </notes>
       <segment state="translated">
         <source>db(B)</source>
       <target>db(B)</target></segment>
-    </unit><unit id="uof.decibelc.symbol">
+    </unit><unit id="uof.dbc.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:173</note>
+      </notes>
+      <segment state="translated">
+        <source>Decibel</source>
+      <target>Decibel</target></segment>
+    </unit><unit id="uof.dbc.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:174</note>
       </notes>
@@ -1514,42 +1532,42 @@
       <segment state="translated">
         <source>W</source>
       <target>W</target></segment>
-    </unit><unit id="uof.kilowatt.name">
+    </unit><unit id="uof.kw.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:181</note>
       </notes>
       <segment state="translated">
         <source>Kilowatt</source>
       <target>Kilowatt</target></segment>
-    </unit><unit id="uof.kilowatt.symbol">
+    </unit><unit id="uof.kw.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:182</note>
       </notes>
       <segment state="translated">
         <source>kW</source>
       <target>kW</target></segment>
-    </unit><unit id="uof.megawatt.name">
+    </unit><unit id="uof.mw.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:185</note>
       </notes>
       <segment state="translated">
         <source>Megawatt</source>
       <target>Megawatt</target></segment>
-    </unit><unit id="uof.megawatt.symbol">
+    </unit><unit id="uof.mw.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:186</note>
       </notes>
       <segment state="translated">
         <source>MW</source>
       <target>MW</target></segment>
-    </unit><unit id="uof.gigawatt.name">
+    </unit><unit id="uof.gw.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:189</note>
       </notes>
       <segment state="translated">
         <source>Gigawatt</source>
       <target>Gigawatt</target></segment>
-    </unit><unit id="uof.gigawatt.symbol">
+    </unit><unit id="uof.gw.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:190</note>
       </notes>
@@ -1570,14 +1588,14 @@
       <segment state="translated">
         <source>kVA</source>
       <target>kVA</target></segment>
-    </unit><unit id="uof.kA.name">
+    </unit><unit id="uof.ka.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:197</note>
       </notes>
       <segment state="translated">
         <source>Ampère</source>
       <target>Ampère</target></segment>
-    </unit><unit id="uof.kA.symbol">
+    </unit><unit id="uof.ka.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:198</note>
       </notes>
@@ -1598,14 +1616,14 @@
       <segment state="translated">
         <source>V</source>
       <target>V</target></segment>
-    </unit><unit id="uof.kilovolt.name">
+    </unit><unit id="uof.kv.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:205</note>
       </notes>
       <segment state="translated">
         <source>Kilovolt</source>
       <target>Kilovolt</target></segment>
-    </unit><unit id="uof.kilovolt.symbol">
+    </unit><unit id="uof.kv.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:206</note>
       </notes>

--- a/src/i18n/messages.nl.xlf
+++ b/src/i18n/messages.nl.xlf
@@ -334,6 +334,20 @@
       <segment state="translated">
         <source>Organization Details</source>
       <target>Organisatie Details</target></segment>
+    </unit><unit id="1367870144394891892">
+      <notes>
+        <note category="location">src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.html:5</note>
+      </notes>
+      <segment state="translated">
+        <source>Enter Name</source>
+      <target>Voer naam in</target></segment>
+    </unit><unit id="8887635712969424708">
+      <notes>
+        <note category="location">src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.html:10</note>
+      </notes>
+      <segment state="translated">
+        <source>Enter Symbol</source>
+      <target>Voer symbool in</target></segment>
     </unit><unit id="3797778920049399855">
       <notes>
         
@@ -591,7 +605,7 @@
       <notes>
 
 
-      <note category="location">src/app/form-controls/datastream/datastream.component.html:75</note><note category="location">src/app/form-controls/sensor/sensor.component.html:40</note></notes>
+      <note category="location">src/app/form-controls/datastream/datastream.component.html:79</note><note category="location">src/app/form-controls/sensor/sensor.component.html:40</note></notes>
       <segment state="translated">
         <source>Enter URL of documentation</source>
       <target>Voer de documentatie URL in</target></segment>
@@ -645,7 +659,7 @@
 
 
 
-      <note category="location">src/app/components/observation-goal/observation-goal.component.html:41</note><note category="location">src/app/form-controls/datastream/datastream.component.html:79</note><note category="location">src/app/form-controls/datastream/datastream.component.html:88</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:12</note><note category="location">src/app/form-controls/sensor/sensor.component.html:44</note></notes>
+      <note category="location">src/app/components/observation-goal/observation-goal.component.html:41</note><note category="location">src/app/form-controls/datastream/datastream.component.html:83</note><note category="location">src/app/form-controls/datastream/datastream.component.html:92</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:12</note><note category="location">src/app/form-controls/sensor/sensor.component.html:44</note></notes>
       <segment state="translated">
         <source>Not a valid URL</source>
       <target>Geen valide URL</target></segment>
@@ -820,7 +834,7 @@
     </unit><unit id="8254163730790501097">
       <notes>
 
-      <note category="location">src/app/components/observation-goal/observation-goal.component.html:33</note><note category="location">src/app/components/observation-goal/observation-goal.component.html:38</note><note category="location">src/app/form-controls/datastream/datastream.component.html:4</note><note category="location">src/app/form-controls/datastream/datastream.component.html:30</note><note category="location">src/app/form-controls/datastream/datastream.component.html:37</note><note category="location">src/app/form-controls/datastream/datastream.component.html:74</note><note category="location">src/app/form-controls/datastream/datastream.component.html:83</note><note category="location">src/app/form-controls/datastream/datastream.component.html:92</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:9</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:16</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:21</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:32</note><note category="location">src/app/form-controls/sensor/sensor.component.html:3</note><note category="location">src/app/form-controls/sensor/sensor.component.html:31</note><note category="location">src/app/form-controls/sensor/sensor.component.html:35</note><note category="location">src/app/form-controls/sensor/sensor.component.html:39</note><note category="location">src/app/form-controls/theme/theme.component.html:2</note><note category="location">src/app/forms/device/device.component.html:37</note><note category="location">src/app/forms/device/device.component.html:41</note><note category="location">src/app/forms/device/device.component.html:46</note><note category="location">src/app/forms/device/device.component.html:50</note></notes>
+      <note category="location">src/app/components/observation-goal/observation-goal.component.html:33</note><note category="location">src/app/components/observation-goal/observation-goal.component.html:38</note><note category="location">src/app/form-controls/datastream/datastream.component.html:4</note><note category="location">src/app/form-controls/datastream/datastream.component.html:30</note><note category="location">src/app/form-controls/datastream/datastream.component.html:37</note><note category="location">src/app/form-controls/datastream/datastream.component.html:74</note><note category="location">src/app/form-controls/datastream/datastream.component.html:78</note><note category="location">src/app/form-controls/datastream/datastream.component.html:87</note><note category="location">src/app/form-controls/datastream/datastream.component.html:96</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:9</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:16</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:21</note><note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:32</note><note category="location">src/app/form-controls/sensor/sensor.component.html:3</note><note category="location">src/app/form-controls/sensor/sensor.component.html:31</note><note category="location">src/app/form-controls/sensor/sensor.component.html:35</note><note category="location">src/app/form-controls/sensor/sensor.component.html:39</note><note category="location">src/app/form-controls/theme/theme.component.html:2</note><note category="location">src/app/forms/device/device.component.html:37</note><note category="location">src/app/forms/device/device.component.html:41</note><note category="location">src/app/forms/device/device.component.html:46</note><note category="location">src/app/forms/device/device.component.html:50</note></notes>
       <segment state="translated">
         <source> - Optional</source>
       <target> - Optioneel</target></segment>
@@ -909,24 +923,31 @@
       <segment state="translated">
         <source>Is Reusable</source>
       <target>Is Herbruikbaar</target></segment>
+    </unit><unit id="1752037547151431451">
+      <notes>
+        <note category="location">src/app/form-controls/datastream/datastream.component.html:74</note>
+      </notes>
+      <segment state="translated">
+        <source>Unit Of Measurement</source>
+      <target>Meeteenheid</target></segment>
     </unit><unit id="4895326106573044490">
       <notes>
 
-      <note category="location">src/app/form-controls/datastream/datastream.component.html:74</note><note category="location">src/app/form-controls/sensor/sensor.component.html:39</note></notes>
+      <note category="location">src/app/form-controls/datastream/datastream.component.html:78</note><note category="location">src/app/form-controls/sensor/sensor.component.html:39</note></notes>
       <segment state="translated">
         <source>Documentation</source>
       <target>Documentatie</target></segment>
     </unit><unit id="8732411010010701151">
       <notes>
 
-      <note category="location">src/app/form-controls/datastream/datastream.component.html:83</note></notes>
+      <note category="location">src/app/form-controls/datastream/datastream.component.html:87</note></notes>
       <segment state="translated">
         <source>Datalink</source>
       <target>Datalink</target></segment>
     </unit><unit id="3465033560498443683">
       <notes>
 
-      <note category="location">src/app/form-controls/datastream/datastream.component.html:84</note></notes>
+      <note category="location">src/app/form-controls/datastream/datastream.component.html:88</note></notes>
       <segment state="translated">
         <source>Enter URL of data</source>
       <target>Voer URL van de data in</target></segment>
@@ -951,6 +972,1150 @@
       <segment state="translated">
         <source>Camera</source>
       <target>Camera</target></segment>
+    </unit><unit id="uof.gram.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:3</note>
+      </notes>
+      <segment state="translated">
+        <source>Gram</source>
+      <target>Gram</target></segment>
+    </unit><unit id="uof.gram.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:4</note>
+      </notes>
+      <segment state="translated">
+        <source>g</source>
+      <target>g</target></segment>
+    </unit><unit id="uof.kilogram.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:7</note>
+      </notes>
+      <segment state="translated">
+        <source>Kilogram</source>
+      <target>Kilogram</target></segment>
+    </unit><unit id="uof.kilogram.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:8</note>
+      </notes>
+      <segment state="translated">
+        <source>kg</source>
+      <target>kg</target></segment>
+    </unit><unit id="uof.ton.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:11</note>
+      </notes>
+      <segment state="translated">
+        <source>Tonne</source>
+      <target>Ton</target></segment>
+    </unit><unit id="uof.ton.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:12</note>
+      </notes>
+      <segment state="translated">
+        <source>t</source>
+      <target>t</target></segment>
+    </unit><unit id="uof.ounce.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:15</note>
+      </notes>
+      <segment state="translated">
+        <source>Ounce</source>
+      <target>Ons</target></segment>
+    </unit><unit id="uof.ounce.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:16</note>
+      </notes>
+      <segment state="translated">
+        <source>oz</source>
+      <target>oz</target></segment>
+    </unit><unit id="uof.pound.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:19</note>
+      </notes>
+      <segment state="translated">
+        <source>Pound</source>
+      <target>Pond</target></segment>
+    </unit><unit id="uof.pound.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:20</note>
+      </notes>
+      <segment state="translated">
+        <source>lb</source>
+      <target>lb</target></segment>
+    </unit><unit id="uof.millimeter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:26</note>
+      </notes>
+      <segment state="translated">
+        <source>Millimeter</source>
+      <target>Millimeter</target></segment>
+    </unit><unit id="uof.millimeter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:27</note>
+      </notes>
+      <segment state="translated">
+        <source>mm</source>
+      <target>mm</target></segment>
+    </unit><unit id="uof.centimeter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:30</note>
+      </notes>
+      <segment state="translated">
+        <source>Centimeter</source>
+      <target>Centimeter</target></segment>
+    </unit><unit id="uof.centimeter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:31</note>
+      </notes>
+      <segment state="translated">
+        <source>cm</source>
+      <target>cm</target></segment>
+    </unit><unit id="uof.meter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:34</note>
+      </notes>
+      <segment state="translated">
+        <source>Meter</source>
+      <target>Meter</target></segment>
+    </unit><unit id="uof.meter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:35</note>
+      </notes>
+      <segment state="translated">
+        <source>m</source>
+      <target>m</target></segment>
+    </unit><unit id="uof.kilometer.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:38</note>
+      </notes>
+      <segment state="translated">
+        <source>Kilometer</source>
+      <target>Kilometer</target></segment>
+    </unit><unit id="uof.kilometer.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:39</note>
+      </notes>
+      <segment state="translated">
+        <source>km</source>
+      <target>km</target></segment>
+    </unit><unit id="uof.inch.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:42</note>
+      </notes>
+      <segment state="translated">
+        <source>Inch</source>
+      <target>Inch</target></segment>
+    </unit><unit id="uof.inch.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:43</note>
+      </notes>
+      <segment state="translated">
+        <source>in</source>
+      <target>in</target></segment>
+    </unit><unit id="uof.feet.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:46</note>
+      </notes>
+      <segment state="translated">
+        <source>Feet</source>
+      <target>Voet</target></segment>
+    </unit><unit id="uof.ft.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:47</note>
+      </notes>
+      <segment state="translated">
+        <source>ft</source>
+      <target>ft</target></segment>
+    </unit><unit id="uof.mile.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:50</note>
+      </notes>
+      <segment state="translated">
+        <source>Mile</source>
+      <target>Mijl</target></segment>
+    </unit><unit id="uof.mile.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:51</note>
+      </notes>
+      <segment state="translated">
+        <source>mi</source>
+      <target>mi</target></segment>
+    </unit><unit id="uof.mm2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:57</note>
+      </notes>
+      <segment state="translated">
+        <source>Square millimeter</source>
+      <target>Vierkante millimeter</target></segment>
+    </unit><unit id="uof.mm2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:58</note>
+      </notes>
+      <segment state="translated">
+        <source>mm2</source>
+      <target>mm2</target></segment>
+    </unit><unit id="uof.cm2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:61</note>
+      </notes>
+      <segment state="translated">
+        <source>Square centimeter</source>
+      <target>Vierkante centimeter</target></segment>
+    </unit><unit id="uof.cm2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:62</note>
+      </notes>
+      <segment state="translated">
+        <source>cm2</source>
+      <target>cm2</target></segment>
+    </unit><unit id="uof.m2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:65</note>
+      </notes>
+      <segment state="translated">
+        <source>Square meter</source>
+      <target>Vierkante meter</target></segment>
+    </unit><unit id="uof.m2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:66</note>
+      </notes>
+      <segment state="translated">
+        <source>m2</source>
+      <target>m2</target></segment>
+    </unit><unit id="uof.km2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:69</note>
+      </notes>
+      <segment state="translated">
+        <source>Square kilometer</source>
+      <target>Vierkante kilometer</target></segment>
+    </unit><unit id="uof.km2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:70</note>
+      </notes>
+      <segment state="translated">
+        <source>km2</source>
+      <target>km2</target></segment>
+    </unit><unit id="uof.hectare.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:73</note>
+      </notes>
+      <segment state="translated">
+        <source>Hectare</source>
+      <target>Hectare</target></segment>
+    </unit><unit id="uof.hectare.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:74</note>
+      </notes>
+      <segment state="translated">
+        <source>ha</source>
+      <target>ha</target></segment>
+    </unit><unit id="uof.sqft.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:77</note>
+      </notes>
+      <segment state="translated">
+        <source>Square feet</source>
+      <target>Vierkante voet</target></segment>
+    </unit><unit id="uof.sqft.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:78</note>
+      </notes>
+      <segment state="translated">
+        <source>sqft</source>
+      <target>sqft</target></segment>
+    </unit><unit id="uof.acre.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:81</note>
+      </notes>
+      <segment state="translated">
+        <source>Acre</source>
+      <target>Acre</target></segment>
+    </unit><unit id="uof.acre.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:82</note>
+      </notes>
+      <segment state="translated">
+        <source>acre</source>
+      <target>acre</target></segment>
+    </unit><unit id="uof.seconds.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:88</note>
+      </notes>
+      <segment state="translated">
+        <source>Seconds</source>
+      <target>Seconden</target></segment>
+    </unit><unit id="uof.seconds.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:89</note>
+      </notes>
+      <segment state="translated">
+        <source>s</source>
+      <target>s</target></segment>
+    </unit><unit id="uof.minutes.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:92</note>
+      </notes>
+      <segment state="translated">
+        <source>Minutes</source>
+      <target>Minuten</target></segment>
+    </unit><unit id="uof.minutes.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:93</note>
+      </notes>
+      <segment state="translated">
+        <source>m</source>
+      <target>m</target></segment>
+    </unit><unit id="uof.hours.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:96</note>
+      </notes>
+      <segment state="translated">
+        <source>Hours</source>
+      <target>Uren</target></segment>
+    </unit><unit id="uof.hours.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:97</note>
+      </notes>
+      <segment state="translated">
+        <source>h</source>
+      <target>h</target></segment>
+    </unit><unit id="uof.days.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:100</note>
+      </notes>
+      <segment state="translated">
+        <source>Days</source>
+      <target>Dagen</target></segment>
+    </unit><unit id="uof.days.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:101</note>
+      </notes>
+      <segment state="translated">
+        <source>d</source>
+      <target>d</target></segment>
+    </unit><unit id="uof.months.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:104</note>
+      </notes>
+      <segment state="translated">
+        <source>Months</source>
+      <target>Maanden</target></segment>
+    </unit><unit id="uof.months.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:105</note>
+      </notes>
+      <segment state="translated">
+        <source>m</source>
+      <target>m</target></segment>
+    </unit><unit id="uof.years.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:108</note>
+      </notes>
+      <segment state="translated">
+        <source>Years</source>
+      <target>Jaren</target></segment>
+    </unit><unit id="uof.years.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:109</note>
+      </notes>
+      <segment state="translated">
+        <source>y</source>
+      <target>y</target></segment>
+    </unit><unit id="uof.wh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:115</note>
+      </notes>
+      <segment state="translated">
+        <source>Watt hour</source>
+      <target>Watt uur</target></segment>
+    </unit><unit id="uof.wh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:116</note>
+      </notes>
+      <segment state="translated">
+        <source>Wh</source>
+      <target>Wh</target></segment>
+    </unit><unit id="uof.kwh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:119</note>
+      </notes>
+      <segment state="translated">
+        <source>Kilowatt hour</source>
+      <target>Kilowatt uur</target></segment>
+    </unit><unit id="uof.kwh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:120</note>
+      </notes>
+      <segment state="translated">
+        <source>kWh</source>
+      <target>kWh</target></segment>
+    </unit><unit id="uof.mwh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:123</note>
+      </notes>
+      <segment state="translated">
+        <source>Megawatt hour</source>
+      <target>Megawatt uur</target></segment>
+    </unit><unit id="uof.mwh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:124</note>
+      </notes>
+      <segment state="translated">
+        <source>MWh</source>
+      <target>MWh</target></segment>
+    </unit><unit id="uof.gwh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:127</note>
+      </notes>
+      <segment state="translated">
+        <source>Gigawatt hour</source>
+      <target>Gigawatt uur</target></segment>
+    </unit><unit id="uof.gwh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:128</note>
+      </notes>
+      <segment state="translated">
+        <source>GWh</source>
+      <target>GWh</target></segment>
+    </unit><unit id="uof.twh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:131</note>
+      </notes>
+      <segment state="translated">
+        <source>Terawatt hour</source>
+      <target>Terawatt uur</target></segment>
+    </unit><unit id="uof.twh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:132</note>
+      </notes>
+      <segment state="translated">
+        <source>TWh</source>
+      <target>TWh</target></segment>
+    </unit><unit id="uof.toe.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:135</note>
+      </notes>
+      <segment state="translated">
+        <source>Tonnes of oil-equivalent</source>
+      <target>Ton olie-equivalent</target></segment>
+    </unit><unit id="uof.toe.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:136</note>
+      </notes>
+      <segment state="translated">
+        <source>toe</source>
+      <target>toe</target></segment>
+    </unit><unit id="uof.ktCo2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:139</note>
+      </notes>
+      <segment state="translated">
+        <source>CO2-equivalent in kilotonnes</source>
+      <target>CO2-equivalent in kiloton</target></segment>
+    </unit><unit id="uof.ktCo2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:140</note>
+      </notes>
+      <segment state="translated">
+        <source>ktCo2</source>
+      <target>ktCo2</target></segment>
+    </unit><unit id="uof.bar.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:146</note>
+      </notes>
+      <segment state="translated">
+        <source>Bar</source>
+      <target>Bar</target></segment>
+    </unit><unit id="uof.bar.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:147</note>
+      </notes>
+      <segment state="translated">
+        <source>bar</source>
+      <target>bar</target></segment>
+    </unit><unit id="uof.mbar.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:150</note>
+      </notes>
+      <segment state="translated">
+        <source>Millibar</source>
+      <target>Millibar</target></segment>
+    </unit><unit id="uof.mbar.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:151</note>
+      </notes>
+      <segment state="translated">
+        <source>mbar</source>
+      <target>mbar</target></segment>
+    </unit><unit id="uof.pascal.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:154</note>
+      </notes>
+      <segment state="translated">
+        <source>Pascal</source>
+      <target>Pascal</target></segment>
+    </unit><unit id="uof.pascal.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:155</note>
+      </notes>
+      <segment state="translated">
+        <source>Pa</source>
+      <target>Pa</target></segment>
+    </unit><unit id="uof.decibel.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:161</note>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:165</note>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:169</note>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:173</note>
+      </notes>
+      <segment state="translated">
+        <source>Decibel</source>
+      <target>Decibel</target></segment>
+    </unit><unit id="uof.decibel.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:162</note>
+      </notes>
+      <segment state="translated">
+        <source>db</source>
+      <target>db</target></segment>
+    </unit><unit id="uof.decibela.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:166</note>
+      </notes>
+      <segment state="translated">
+        <source>db(A)</source>
+      <target>db(A)</target></segment>
+    </unit><unit id="uof.decibelb.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:170</note>
+      </notes>
+      <segment state="translated">
+        <source>db(B)</source>
+      <target>db(B)</target></segment>
+    </unit><unit id="uof.decibelc.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:174</note>
+      </notes>
+      <segment state="translated">
+        <source>db(C)</source>
+      <target>db(C)</target></segment>
+    </unit><unit id="uof.watt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:177</note>
+      </notes>
+      <segment state="translated">
+        <source>Watt</source>
+      <target>Watt</target></segment>
+    </unit><unit id="uof.watt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:178</note>
+      </notes>
+      <segment state="translated">
+        <source>W</source>
+      <target>W</target></segment>
+    </unit><unit id="uof.kilowatt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:181</note>
+      </notes>
+      <segment state="translated">
+        <source>Kilowatt</source>
+      <target>Kilowatt</target></segment>
+    </unit><unit id="uof.kilowatt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:182</note>
+      </notes>
+      <segment state="translated">
+        <source>kW</source>
+      <target>kW</target></segment>
+    </unit><unit id="uof.megawatt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:185</note>
+      </notes>
+      <segment state="translated">
+        <source>Megawatt</source>
+      <target>Megawatt</target></segment>
+    </unit><unit id="uof.megawatt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:186</note>
+      </notes>
+      <segment state="translated">
+        <source>MW</source>
+      <target>MW</target></segment>
+    </unit><unit id="uof.gigawatt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:189</note>
+      </notes>
+      <segment state="translated">
+        <source>Gigawatt</source>
+      <target>Gigawatt</target></segment>
+    </unit><unit id="uof.gigawatt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:190</note>
+      </notes>
+      <segment state="translated">
+        <source>GW</source>
+      <target>GW</target></segment>
+    </unit><unit id="uof.kva.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:193</note>
+      </notes>
+      <segment state="translated">
+        <source>Kilovolt-Ampère</source>
+      <target>Kilovolt-Ampère</target></segment>
+    </unit><unit id="uof.kva.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:194</note>
+      </notes>
+      <segment state="translated">
+        <source>kVA</source>
+      <target>kVA</target></segment>
+    </unit><unit id="uof.kA.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:197</note>
+      </notes>
+      <segment state="translated">
+        <source>Ampère</source>
+      <target>Ampère</target></segment>
+    </unit><unit id="uof.kA.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:198</note>
+      </notes>
+      <segment state="translated">
+        <source>kA</source>
+      <target>kA</target></segment>
+    </unit><unit id="uof.volt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:201</note>
+      </notes>
+      <segment state="translated">
+        <source>Volt</source>
+      <target>Volt</target></segment>
+    </unit><unit id="uof.volt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:202</note>
+      </notes>
+      <segment state="translated">
+        <source>V</source>
+      <target>V</target></segment>
+    </unit><unit id="uof.kilovolt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:205</note>
+      </notes>
+      <segment state="translated">
+        <source>Kilovolt</source>
+      <target>Kilovolt</target></segment>
+    </unit><unit id="uof.kilovolt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:206</note>
+      </notes>
+      <segment state="translated">
+        <source>kV</source>
+      <target>kV</target></segment>
+    </unit><unit id="uof.mps.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:212</note>
+      </notes>
+      <segment state="translated">
+        <source>Meters per second</source>
+      <target>Meter per seconde</target></segment>
+    </unit><unit id="uof.mps.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:213</note>
+      </notes>
+      <segment state="translated">
+        <source>m/s</source>
+      <target>m/s</target></segment>
+    </unit><unit id="uof.kmps.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:216</note>
+      </notes>
+      <segment state="translated">
+        <source>Kilometers per second</source>
+      <target>Kilometer per seconde</target></segment>
+    </unit><unit id="uof.kmps.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:217</note>
+      </notes>
+      <segment state="translated">
+        <source>km/s</source>
+      <target>km/s</target></segment>
+    </unit><unit id="uof.kmph.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:220</note>
+      </notes>
+      <segment state="translated">
+        <source>Kilometers per hour</source>
+      <target>Kilometer per uur</target></segment>
+    </unit><unit id="uof.kmph.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:221</note>
+      </notes>
+      <segment state="translated">
+        <source>km/h</source>
+      <target>km/h</target></segment>
+    </unit><unit id="uof.mph.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:224</note>
+      </notes>
+      <segment state="translated">
+        <source>Mile per hour</source>
+      <target>Mijl per uur</target></segment>
+    </unit><unit id="uof.mph.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:225</note>
+      </notes>
+      <segment state="translated">
+        <source>mph</source>
+      <target>mph</target></segment>
+    </unit><unit id="uof.celcius.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:231</note>
+      </notes>
+      <segment state="translated">
+        <source>Celsius</source>
+      <target>Celsius</target></segment>
+    </unit><unit id="uof.celcius.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:232</note>
+      </notes>
+      <segment state="translated">
+        <source>C</source>
+      <target>C</target></segment>
+    </unit><unit id="uof.fahrenheit.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:235</note>
+      </notes>
+      <segment state="translated">
+        <source>Fahrenheit</source>
+      <target>Fahrenheit</target></segment>
+    </unit><unit id="uof.fahrenheit.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:236</note>
+      </notes>
+      <segment state="translated">
+        <source>F</source>
+      <target>F</target></segment>
+    </unit><unit id="uof.kelvin.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:239</note>
+      </notes>
+      <segment state="translated">
+        <source>Kelvin</source>
+      <target>Kelvin</target></segment>
+    </unit><unit id="uof.kelvin.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:240</note>
+      </notes>
+      <segment state="translated">
+        <source>K</source>
+      <target>K</target></segment>
+    </unit><unit id="uof.cm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:246</note>
+      </notes>
+      <segment state="translated">
+        <source>Cubic centimeter</source>
+      <target>Kubieke centimeter</target></segment>
+    </unit><unit id="uof.cm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:247</note>
+      </notes>
+      <segment state="translated">
+        <source>cm3</source>
+      <target>cm3</target></segment>
+    </unit><unit id="uof.dm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:250</note>
+      </notes>
+      <segment state="translated">
+        <source>Cubic decimeter</source>
+      <target>Kubieke decimeter</target></segment>
+    </unit><unit id="uof.dm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:251</note>
+      </notes>
+      <segment state="translated">
+        <source>dm3</source>
+      <target>dm3</target></segment>
+    </unit><unit id="uof.m3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:254</note>
+      </notes>
+      <segment state="translated">
+        <source>Cubic meter</source>
+      <target>Kubieke meter</target></segment>
+    </unit><unit id="uof.m3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:255</note>
+      </notes>
+      <segment state="translated">
+        <source>m3</source>
+      <target>m3</target></segment>
+    </unit><unit id="uof.liter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:258</note>
+      </notes>
+      <segment state="translated">
+        <source>Liter</source>
+      <target>Liter</target></segment>
+    </unit><unit id="uof.liter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:259</note>
+      </notes>
+      <segment state="translated">
+        <source>L</source>
+      <target>L</target></segment>
+    </unit><unit id="uof.hectoliter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:262</note>
+      </notes>
+      <segment state="translated">
+        <source>Hectoliter</source>
+      <target>Hectoliter</target></segment>
+    </unit><unit id="uof.hectoliter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:263</note>
+      </notes>
+      <segment state="translated">
+        <source>hL</source>
+      <target>hL</target></segment>
+    </unit><unit id="uof.hm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:266</note>
+      </notes>
+      <segment state="translated">
+        <source>Cubic hectometer</source>
+      <target>Kubieke hectometer</target></segment>
+    </unit><unit id="uof.hm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:267</note>
+      </notes>
+      <segment state="translated">
+        <source>hm3</source>
+      <target>hm3</target></segment>
+    </unit><unit id="uof.m3s.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:273</note>
+      </notes>
+      <segment state="translated">
+        <source>Cubic meter per second</source>
+      <target>Kubieke meter per seconde</target></segment>
+    </unit><unit id="uof.m3s.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:274</note>
+      </notes>
+      <segment state="translated">
+        <source>m3/s</source>
+      <target>m3/s</target></segment>
+    </unit><unit id="uof.Ls.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:277</note>
+      </notes>
+      <segment state="translated">
+        <source>Liter per second</source>
+      <target>Liter per seconde</target></segment>
+    </unit><unit id="uof.Ls.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:278</note>
+      </notes>
+      <segment state="translated">
+        <source>L/s</source>
+      <target>L/s</target></segment>
+    </unit><unit id="uof.m3h.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:281</note>
+      </notes>
+      <segment state="translated">
+        <source>Cubic meter per hour</source>
+      <target>Kubieke meter per uur</target></segment>
+    </unit><unit id="uof.m3h.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:282</note>
+      </notes>
+      <segment state="translated">
+        <source>m3/h</source>
+      <target>m3/h</target></segment>
+    </unit><unit id="uof.Lh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:285</note>
+      </notes>
+      <segment state="translated">
+        <source>Liter per hour</source>
+      <target>Liter per uur</target></segment>
+    </unit><unit id="uof.Lh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:286</note>
+      </notes>
+      <segment state="translated">
+        <source>L/h</source>
+      <target>L/h</target></segment>
+    </unit><unit id="uof.m3d.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:289</note>
+      </notes>
+      <segment state="translated">
+        <source>Cubic meter per day</source>
+      <target>Kubieke meter per dag</target></segment>
+    </unit><unit id="uof.m3d.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:290</note>
+      </notes>
+      <segment state="translated">
+        <source>m3/d</source>
+      <target>m3/d</target></segment>
+    </unit><unit id="uof.Ld.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:293</note>
+      </notes>
+      <segment state="translated">
+        <source>Liter per day</source>
+      <target>Liter per dag</target></segment>
+    </unit><unit id="uof.Ld.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:294</note>
+      </notes>
+      <segment state="translated">
+        <source>L/d</source>
+      <target>L/d</target></segment>
+    </unit><unit id="uof.ppm.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:300</note>
+      </notes>
+      <segment state="translated">
+        <source>Part per million</source>
+      <target>Deel per miljoen</target></segment>
+    </unit><unit id="uof.ppm.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:301</note>
+      </notes>
+      <segment state="translated">
+        <source>ppm</source>
+      <target>ppm</target></segment>
+    </unit><unit id="uof.µgL.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:307</note>
+      </notes>
+      <segment state="translated">
+        <source>Microgram per liter</source>
+      <target>Microgram per liter</target></segment>
+    </unit><unit id="uof.µgL.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:308</note>
+      </notes>
+      <segment state="translated">
+        <source>µg/L</source>
+      <target>µg/L</target></segment>
+    </unit><unit id="uof.mgL.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:311</note>
+      </notes>
+      <segment state="translated">
+        <source>Miligram per liter</source>
+      <target>Miligram per liter</target></segment>
+    </unit><unit id="uof.mgL.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:312</note>
+      </notes>
+      <segment state="translated">
+        <source>mg/L</source>
+      <target>mg/L</target></segment>
+    </unit><unit id="uof.µgm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:315</note>
+      </notes>
+      <segment state="translated">
+        <source>Microgram per cubic meter</source>
+      <target>Microgram per kubische meter</target></segment>
+    </unit><unit id="uof.µgm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:316</note>
+      </notes>
+      <segment state="translated">
+        <source>µ5g/m3</source>
+      <target>µ5g/m3</target></segment>
+    </unit><unit id="uof.mgm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:319</note>
+      </notes>
+      <segment state="translated">
+        <source>Milligram per cubic meter</source>
+      <target>Milligram per kubische meter</target></segment>
+    </unit><unit id="uof.mgm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:320</note>
+      </notes>
+      <segment state="translated">
+        <source>mg/m3</source>
+      <target>mg/m3</target></segment>
+    </unit><unit id="uof.gL.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:323</note>
+      </notes>
+      <segment state="translated">
+        <source>Gram per liter</source>
+      <target>Gram per liter</target></segment>
+    </unit><unit id="uof.gL.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:324</note>
+      </notes>
+      <segment state="translated">
+        <source>g/L</source>
+      <target>g/L</target></segment>
+    </unit><unit id="uof.kgm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:327</note>
+      </notes>
+      <segment state="translated">
+        <source>Kilogram per cubic meter</source>
+      <target>Kilogram per kubische meter</target></segment>
+    </unit><unit id="uof.kgm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:328</note>
+      </notes>
+      <segment state="translated">
+        <source>kg/m3</source>
+      <target>kg/m3</target></segment>
+    </unit><unit id="uof.byte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:334</note>
+      </notes>
+      <segment state="translated">
+        <source>Byte</source>
+      <target>Byte</target></segment>
+    </unit><unit id="uof.byte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:335</note>
+      </notes>
+      <segment state="translated">
+        <source>B</source>
+      <target>B</target></segment>
+    </unit><unit id="uof.kilobyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:338</note>
+      </notes>
+      <segment state="translated">
+        <source>Kilobyte</source>
+      <target>Kilobyte</target></segment>
+    </unit><unit id="uof.kilobyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:339</note>
+      </notes>
+      <segment state="translated">
+        <source>kB</source>
+      <target>kB</target></segment>
+    </unit><unit id="uof.megabyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:342</note>
+      </notes>
+      <segment state="translated">
+        <source>Megabyte</source>
+      <target>Megabyte</target></segment>
+    </unit><unit id="uof.megabyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:343</note>
+      </notes>
+      <segment state="translated">
+        <source>MB</source>
+      <target>MB</target></segment>
+    </unit><unit id="uof.gigabyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:346</note>
+      </notes>
+      <segment state="translated">
+        <source>Gigabyte</source>
+      <target>Gigabyte</target></segment>
+    </unit><unit id="uof.gigabyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:347</note>
+      </notes>
+      <segment state="translated">
+        <source>GB</source>
+      <target>GB</target></segment>
+    </unit><unit id="uof.terabyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:350</note>
+      </notes>
+      <segment state="translated">
+        <source>Terabyte</source>
+      <target>Terabyte</target></segment>
+    </unit><unit id="uof.terabyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:351</note>
+      </notes>
+      <segment state="translated">
+        <source>TB</source>
+      <target>TB</target></segment>
+    </unit><unit id="uof.petabyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:354</note>
+      </notes>
+      <segment state="translated">
+        <source>Petabyte</source>
+      <target>Petabyte</target></segment>
+    </unit><unit id="uof.petabyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:355</note>
+      </notes>
+      <segment state="translated">
+        <source>PB</source>
+      <target>PB</target></segment>
+    </unit><unit id="uof.hertz.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:361</note>
+      </notes>
+      <segment state="translated">
+        <source>Hertz</source>
+      <target>Hertz</target></segment>
+    </unit><unit id="uof.hertz.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:362</note>
+      </notes>
+      <segment state="translated">
+        <source>Hz</source>
+      <target>Hz</target></segment>
+    </unit><unit id="uof.megahertz.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:365</note>
+      </notes>
+      <segment state="translated">
+        <source>Megahertz</source>
+      <target>Megahertz</target></segment>
+    </unit><unit id="uof.megahertz.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:366</note>
+      </notes>
+      <segment state="translated">
+        <source>MHz</source>
+      <target>MHz</target></segment>
+    </unit><unit id="uof.gigahertz.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:369</note>
+      </notes>
+      <segment state="translated">
+        <source>Gigahertz</source>
+      <target>Gigahertz</target></segment>
+    </unit><unit id="uof.gigahertz.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:370</note>
+      </notes>
+      <segment state="translated">
+        <source>GHz</source>
+      <target>GHz</target></segment>
+    </unit><unit id="uof.percentage.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:376</note>
+      </notes>
+      <segment state="translated">
+        <source>Percentage</source>
+      <target>Percentage</target></segment>
+    </unit><unit id="uof.percentage.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:377</note>
+      </notes>
+      <segment state="translated">
+        <source>%</source>
+      <target>%</target></segment>
     </unit><unit id="8682931004646337355">
       <notes>
         <note category="location">src/app/navbar/navbar.component.html:3,4</note>
@@ -1355,7 +2520,7 @@
 
 
 
-      <note category="location">src/app/form-controls/datastream/datastream.component.html:92</note><note category="location">src/app/sidebar/sidebar.component.html:12</note></notes>
+      <note category="location">src/app/form-controls/datastream/datastream.component.html:96</note><note category="location">src/app/sidebar/sidebar.component.html:12</note></notes>
       <segment state="translated">
         <source>Observation Goals</source>
       <target>Observatiedoelen</target></segment>

--- a/src/i18n/messages.xlf
+++ b/src/i18n/messages.xlf
@@ -520,8 +520,9 @@
         <note category="location">src/app/form-controls/datastream/datastream.component.html:30</note>
         <note category="location">src/app/form-controls/datastream/datastream.component.html:37</note>
         <note category="location">src/app/form-controls/datastream/datastream.component.html:74</note>
-        <note category="location">src/app/form-controls/datastream/datastream.component.html:83</note>
-        <note category="location">src/app/form-controls/datastream/datastream.component.html:92</note>
+        <note category="location">src/app/form-controls/datastream/datastream.component.html:78</note>
+        <note category="location">src/app/form-controls/datastream/datastream.component.html:87</note>
+        <note category="location">src/app/form-controls/datastream/datastream.component.html:96</note>
         <note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:9</note>
         <note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:16</note>
         <note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:21</note>
@@ -552,8 +553,8 @@
     <unit id="8651329520452925938">
       <notes>
         <note category="location">src/app/components/observation-goal/observation-goal.component.html:41</note>
-        <note category="location">src/app/form-controls/datastream/datastream.component.html:79</note>
-        <note category="location">src/app/form-controls/datastream/datastream.component.html:88</note>
+        <note category="location">src/app/form-controls/datastream/datastream.component.html:83</note>
+        <note category="location">src/app/form-controls/datastream/datastream.component.html:92</note>
         <note category="location">src/app/form-controls/organization-contact/organization-contact.component.html:12</note>
         <note category="location">src/app/form-controls/sensor/sensor.component.html:44</note>
       </notes>
@@ -662,6 +663,22 @@
         <source>Organization Details</source>
       </segment>
     </unit>
+    <unit id="1367870144394891892">
+      <notes>
+        <note category="location">src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.html:5</note>
+      </notes>
+      <segment>
+        <source>Enter Name</source>
+      </segment>
+    </unit>
+    <unit id="8887635712969424708">
+      <notes>
+        <note category="location">src/app/form-controls/datastream-unit-of-measurement/unit-of-measurement.component.html:10</note>
+      </notes>
+      <segment>
+        <source>Enter Symbol</source>
+      </segment>
+    </unit>
     <unit id="5546023389249689964">
       <notes>
         <note category="location">src/app/form-controls/datastream/datastream.component.html:4</note>
@@ -751,9 +768,17 @@
         <source>Is Reusable</source>
       </segment>
     </unit>
-    <unit id="4895326106573044490">
+    <unit id="1752037547151431451">
       <notes>
         <note category="location">src/app/form-controls/datastream/datastream.component.html:74</note>
+      </notes>
+      <segment>
+        <source>Unit Of Measurement</source>
+      </segment>
+    </unit>
+    <unit id="4895326106573044490">
+      <notes>
+        <note category="location">src/app/form-controls/datastream/datastream.component.html:78</note>
         <note category="location">src/app/form-controls/sensor/sensor.component.html:39</note>
       </notes>
       <segment>
@@ -762,7 +787,7 @@
     </unit>
     <unit id="5880667752120449727">
       <notes>
-        <note category="location">src/app/form-controls/datastream/datastream.component.html:75</note>
+        <note category="location">src/app/form-controls/datastream/datastream.component.html:79</note>
         <note category="location">src/app/form-controls/sensor/sensor.component.html:40</note>
       </notes>
       <segment>
@@ -771,7 +796,7 @@
     </unit>
     <unit id="8732411010010701151">
       <notes>
-        <note category="location">src/app/form-controls/datastream/datastream.component.html:83</note>
+        <note category="location">src/app/form-controls/datastream/datastream.component.html:87</note>
       </notes>
       <segment>
         <source>Datalink</source>
@@ -779,7 +804,7 @@
     </unit>
     <unit id="3465033560498443683">
       <notes>
-        <note category="location">src/app/form-controls/datastream/datastream.component.html:84</note>
+        <note category="location">src/app/form-controls/datastream/datastream.component.html:88</note>
       </notes>
       <segment>
         <source>Enter URL of data</source>
@@ -787,7 +812,7 @@
     </unit>
     <unit id="9075163810858994898">
       <notes>
-        <note category="location">src/app/form-controls/datastream/datastream.component.html:92</note>
+        <note category="location">src/app/form-controls/datastream/datastream.component.html:96</note>
         <note category="location">src/app/sidebar/sidebar.component.html:12</note>
       </notes>
       <segment>
@@ -1624,6 +1649,1313 @@
       </notes>
       <segment>
         <source>Camera</source>
+      </segment>
+    </unit>
+    <unit id="uof.gram.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:3</note>
+      </notes>
+      <segment>
+        <source>Gram</source>
+      </segment>
+    </unit>
+    <unit id="uof.gram.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:4</note>
+      </notes>
+      <segment>
+        <source>g</source>
+      </segment>
+    </unit>
+    <unit id="uof.kilogram.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:7</note>
+      </notes>
+      <segment>
+        <source>Kilogram</source>
+      </segment>
+    </unit>
+    <unit id="uof.kilogram.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:8</note>
+      </notes>
+      <segment>
+        <source>kg</source>
+      </segment>
+    </unit>
+    <unit id="uof.ton.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:11</note>
+      </notes>
+      <segment>
+        <source>Tonne</source>
+      </segment>
+    </unit>
+    <unit id="uof.ton.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:12</note>
+      </notes>
+      <segment>
+        <source>t</source>
+      </segment>
+    </unit>
+    <unit id="uof.ounce.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:15</note>
+      </notes>
+      <segment>
+        <source>Ounce</source>
+      </segment>
+    </unit>
+    <unit id="uof.ounce.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:16</note>
+      </notes>
+      <segment>
+        <source>oz</source>
+      </segment>
+    </unit>
+    <unit id="uof.pound.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:19</note>
+      </notes>
+      <segment>
+        <source>Pound</source>
+      </segment>
+    </unit>
+    <unit id="uof.pound.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:20</note>
+      </notes>
+      <segment>
+        <source>lb</source>
+      </segment>
+    </unit>
+    <unit id="uof.millimeter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:26</note>
+      </notes>
+      <segment>
+        <source>Millimeter</source>
+      </segment>
+    </unit>
+    <unit id="uof.millimeter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:27</note>
+      </notes>
+      <segment>
+        <source>mm</source>
+      </segment>
+    </unit>
+    <unit id="uof.centimeter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:30</note>
+      </notes>
+      <segment>
+        <source>Centimeter</source>
+      </segment>
+    </unit>
+    <unit id="uof.centimeter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:31</note>
+      </notes>
+      <segment>
+        <source>cm</source>
+      </segment>
+    </unit>
+    <unit id="uof.meter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:34</note>
+      </notes>
+      <segment>
+        <source>Meter</source>
+      </segment>
+    </unit>
+    <unit id="uof.meter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:35</note>
+      </notes>
+      <segment>
+        <source>m</source>
+      </segment>
+    </unit>
+    <unit id="uof.kilometer.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:38</note>
+      </notes>
+      <segment>
+        <source>Kilometer</source>
+      </segment>
+    </unit>
+    <unit id="uof.kilometer.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:39</note>
+      </notes>
+      <segment>
+        <source>km</source>
+      </segment>
+    </unit>
+    <unit id="uof.inch.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:42</note>
+      </notes>
+      <segment>
+        <source>Inch</source>
+      </segment>
+    </unit>
+    <unit id="uof.inch.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:43</note>
+      </notes>
+      <segment>
+        <source>in</source>
+      </segment>
+    </unit>
+    <unit id="uof.feet.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:46</note>
+      </notes>
+      <segment>
+        <source>Feet</source>
+      </segment>
+    </unit>
+    <unit id="uof.ft.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:47</note>
+      </notes>
+      <segment>
+        <source>ft</source>
+      </segment>
+    </unit>
+    <unit id="uof.mile.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:50</note>
+      </notes>
+      <segment>
+        <source>Mile</source>
+      </segment>
+    </unit>
+    <unit id="uof.mile.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:51</note>
+      </notes>
+      <segment>
+        <source>mi</source>
+      </segment>
+    </unit>
+    <unit id="uof.mm2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:57</note>
+      </notes>
+      <segment>
+        <source>Square millimeter</source>
+      </segment>
+    </unit>
+    <unit id="uof.mm2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:58</note>
+      </notes>
+      <segment>
+        <source>mm2</source>
+      </segment>
+    </unit>
+    <unit id="uof.cm2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:61</note>
+      </notes>
+      <segment>
+        <source>Square centimeter</source>
+      </segment>
+    </unit>
+    <unit id="uof.cm2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:62</note>
+      </notes>
+      <segment>
+        <source>cm2</source>
+      </segment>
+    </unit>
+    <unit id="uof.m2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:65</note>
+      </notes>
+      <segment>
+        <source>Square meter</source>
+      </segment>
+    </unit>
+    <unit id="uof.m2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:66</note>
+      </notes>
+      <segment>
+        <source>m2</source>
+      </segment>
+    </unit>
+    <unit id="uof.km2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:69</note>
+      </notes>
+      <segment>
+        <source>Square kilometer</source>
+      </segment>
+    </unit>
+    <unit id="uof.km2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:70</note>
+      </notes>
+      <segment>
+        <source>km2</source>
+      </segment>
+    </unit>
+    <unit id="uof.hectare.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:73</note>
+      </notes>
+      <segment>
+        <source>Hectare</source>
+      </segment>
+    </unit>
+    <unit id="uof.hectare.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:74</note>
+      </notes>
+      <segment>
+        <source>ha</source>
+      </segment>
+    </unit>
+    <unit id="uof.sqft.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:77</note>
+      </notes>
+      <segment>
+        <source>Square feet</source>
+      </segment>
+    </unit>
+    <unit id="uof.sqft.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:78</note>
+      </notes>
+      <segment>
+        <source>sqft</source>
+      </segment>
+    </unit>
+    <unit id="uof.acre.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:81</note>
+      </notes>
+      <segment>
+        <source>Acre</source>
+      </segment>
+    </unit>
+    <unit id="uof.acre.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:82</note>
+      </notes>
+      <segment>
+        <source>acre</source>
+      </segment>
+    </unit>
+    <unit id="uof.seconds.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:88</note>
+      </notes>
+      <segment>
+        <source>Seconds</source>
+      </segment>
+    </unit>
+    <unit id="uof.seconds.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:89</note>
+      </notes>
+      <segment>
+        <source>s</source>
+      </segment>
+    </unit>
+    <unit id="uof.minutes.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:92</note>
+      </notes>
+      <segment>
+        <source>Minutes</source>
+      </segment>
+    </unit>
+    <unit id="uof.minutes.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:93</note>
+      </notes>
+      <segment>
+        <source>m</source>
+      </segment>
+    </unit>
+    <unit id="uof.hours.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:96</note>
+      </notes>
+      <segment>
+        <source>Hours</source>
+      </segment>
+    </unit>
+    <unit id="uof.hours.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:97</note>
+      </notes>
+      <segment>
+        <source>h</source>
+      </segment>
+    </unit>
+    <unit id="uof.days.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:100</note>
+      </notes>
+      <segment>
+        <source>Days</source>
+      </segment>
+    </unit>
+    <unit id="uof.days.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:101</note>
+      </notes>
+      <segment>
+        <source>d</source>
+      </segment>
+    </unit>
+    <unit id="uof.months.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:104</note>
+      </notes>
+      <segment>
+        <source>Months</source>
+      </segment>
+    </unit>
+    <unit id="uof.months.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:105</note>
+      </notes>
+      <segment>
+        <source>m</source>
+      </segment>
+    </unit>
+    <unit id="uof.years.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:108</note>
+      </notes>
+      <segment>
+        <source>Years</source>
+      </segment>
+    </unit>
+    <unit id="uof.years.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:109</note>
+      </notes>
+      <segment>
+        <source>y</source>
+      </segment>
+    </unit>
+    <unit id="uof.wh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:115</note>
+      </notes>
+      <segment>
+        <source>Watt hour</source>
+      </segment>
+    </unit>
+    <unit id="uof.wh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:116</note>
+      </notes>
+      <segment>
+        <source>Wh</source>
+      </segment>
+    </unit>
+    <unit id="uof.kwh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:119</note>
+      </notes>
+      <segment>
+        <source>Kilowatt hour</source>
+      </segment>
+    </unit>
+    <unit id="uof.kwh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:120</note>
+      </notes>
+      <segment>
+        <source>kWh</source>
+      </segment>
+    </unit>
+    <unit id="uof.mwh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:123</note>
+      </notes>
+      <segment>
+        <source>Megawatt hour</source>
+      </segment>
+    </unit>
+    <unit id="uof.mwh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:124</note>
+      </notes>
+      <segment>
+        <source>MWh</source>
+      </segment>
+    </unit>
+    <unit id="uof.gwh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:127</note>
+      </notes>
+      <segment>
+        <source>Gigawatt hour</source>
+      </segment>
+    </unit>
+    <unit id="uof.gwh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:128</note>
+      </notes>
+      <segment>
+        <source>GWh</source>
+      </segment>
+    </unit>
+    <unit id="uof.twh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:131</note>
+      </notes>
+      <segment>
+        <source>Terawatt hour</source>
+      </segment>
+    </unit>
+    <unit id="uof.twh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:132</note>
+      </notes>
+      <segment>
+        <source>TWh</source>
+      </segment>
+    </unit>
+    <unit id="uof.toe.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:135</note>
+      </notes>
+      <segment>
+        <source>Tonnes of oil-equivalent</source>
+      </segment>
+    </unit>
+    <unit id="uof.toe.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:136</note>
+      </notes>
+      <segment>
+        <source>toe</source>
+      </segment>
+    </unit>
+    <unit id="uof.ktCo2.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:139</note>
+      </notes>
+      <segment>
+        <source>CO2-equivalent in kilotonnes</source>
+      </segment>
+    </unit>
+    <unit id="uof.ktCo2.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:140</note>
+      </notes>
+      <segment>
+        <source>ktCo2</source>
+      </segment>
+    </unit>
+    <unit id="uof.bar.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:146</note>
+      </notes>
+      <segment>
+        <source>Bar</source>
+      </segment>
+    </unit>
+    <unit id="uof.bar.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:147</note>
+      </notes>
+      <segment>
+        <source>bar</source>
+      </segment>
+    </unit>
+    <unit id="uof.mbar.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:150</note>
+      </notes>
+      <segment>
+        <source>Millibar</source>
+      </segment>
+    </unit>
+    <unit id="uof.mbar.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:151</note>
+      </notes>
+      <segment>
+        <source>mbar</source>
+      </segment>
+    </unit>
+    <unit id="uof.pascal.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:154</note>
+      </notes>
+      <segment>
+        <source>Pascal</source>
+      </segment>
+    </unit>
+    <unit id="uof.pascal.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:155</note>
+      </notes>
+      <segment>
+        <source>Pa</source>
+      </segment>
+    </unit>
+    <unit id="uof.decibel.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:161</note>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:165</note>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:169</note>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:173</note>
+      </notes>
+      <segment>
+        <source>Decibel</source>
+      </segment>
+    </unit>
+    <unit id="uof.decibel.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:162</note>
+      </notes>
+      <segment>
+        <source>db</source>
+      </segment>
+    </unit>
+    <unit id="uof.decibela.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:166</note>
+      </notes>
+      <segment>
+        <source>db(A)</source>
+      </segment>
+    </unit>
+    <unit id="uof.decibelb.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:170</note>
+      </notes>
+      <segment>
+        <source>db(B)</source>
+      </segment>
+    </unit>
+    <unit id="uof.decibelc.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:174</note>
+      </notes>
+      <segment>
+        <source>db(C)</source>
+      </segment>
+    </unit>
+    <unit id="uof.watt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:177</note>
+      </notes>
+      <segment>
+        <source>Watt</source>
+      </segment>
+    </unit>
+    <unit id="uof.watt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:178</note>
+      </notes>
+      <segment>
+        <source>W</source>
+      </segment>
+    </unit>
+    <unit id="uof.kilowatt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:181</note>
+      </notes>
+      <segment>
+        <source>Kilowatt</source>
+      </segment>
+    </unit>
+    <unit id="uof.kilowatt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:182</note>
+      </notes>
+      <segment>
+        <source>kW</source>
+      </segment>
+    </unit>
+    <unit id="uof.megawatt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:185</note>
+      </notes>
+      <segment>
+        <source>Megawatt</source>
+      </segment>
+    </unit>
+    <unit id="uof.megawatt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:186</note>
+      </notes>
+      <segment>
+        <source>MW</source>
+      </segment>
+    </unit>
+    <unit id="uof.gigawatt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:189</note>
+      </notes>
+      <segment>
+        <source>Gigawatt</source>
+      </segment>
+    </unit>
+    <unit id="uof.gigawatt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:190</note>
+      </notes>
+      <segment>
+        <source>GW</source>
+      </segment>
+    </unit>
+    <unit id="uof.kva.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:193</note>
+      </notes>
+      <segment>
+        <source>Kilovolt-Ampère</source>
+      </segment>
+    </unit>
+    <unit id="uof.kva.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:194</note>
+      </notes>
+      <segment>
+        <source>kVA</source>
+      </segment>
+    </unit>
+    <unit id="uof.kA.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:197</note>
+      </notes>
+      <segment>
+        <source>Ampère</source>
+      </segment>
+    </unit>
+    <unit id="uof.kA.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:198</note>
+      </notes>
+      <segment>
+        <source>kA</source>
+      </segment>
+    </unit>
+    <unit id="uof.volt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:201</note>
+      </notes>
+      <segment>
+        <source>Volt</source>
+      </segment>
+    </unit>
+    <unit id="uof.volt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:202</note>
+      </notes>
+      <segment>
+        <source>V</source>
+      </segment>
+    </unit>
+    <unit id="uof.kilovolt.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:205</note>
+      </notes>
+      <segment>
+        <source>Kilovolt</source>
+      </segment>
+    </unit>
+    <unit id="uof.kilovolt.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:206</note>
+      </notes>
+      <segment>
+        <source>kV</source>
+      </segment>
+    </unit>
+    <unit id="uof.mps.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:212</note>
+      </notes>
+      <segment>
+        <source>Meters per second</source>
+      </segment>
+    </unit>
+    <unit id="uof.mps.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:213</note>
+      </notes>
+      <segment>
+        <source>m/s</source>
+      </segment>
+    </unit>
+    <unit id="uof.kmps.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:216</note>
+      </notes>
+      <segment>
+        <source>Kilometers per second</source>
+      </segment>
+    </unit>
+    <unit id="uof.kmps.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:217</note>
+      </notes>
+      <segment>
+        <source>km/s</source>
+      </segment>
+    </unit>
+    <unit id="uof.kmph.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:220</note>
+      </notes>
+      <segment>
+        <source>Kilometers per hour</source>
+      </segment>
+    </unit>
+    <unit id="uof.kmph.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:221</note>
+      </notes>
+      <segment>
+        <source>km/h</source>
+      </segment>
+    </unit>
+    <unit id="uof.mph.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:224</note>
+      </notes>
+      <segment>
+        <source>Mile per hour</source>
+      </segment>
+    </unit>
+    <unit id="uof.mph.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:225</note>
+      </notes>
+      <segment>
+        <source>mph</source>
+      </segment>
+    </unit>
+    <unit id="uof.celcius.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:231</note>
+      </notes>
+      <segment>
+        <source>Celsius</source>
+      </segment>
+    </unit>
+    <unit id="uof.celcius.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:232</note>
+      </notes>
+      <segment>
+        <source>C</source>
+      </segment>
+    </unit>
+    <unit id="uof.fahrenheit.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:235</note>
+      </notes>
+      <segment>
+        <source>Fahrenheit</source>
+      </segment>
+    </unit>
+    <unit id="uof.fahrenheit.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:236</note>
+      </notes>
+      <segment>
+        <source>F</source>
+      </segment>
+    </unit>
+    <unit id="uof.kelvin.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:239</note>
+      </notes>
+      <segment>
+        <source>Kelvin</source>
+      </segment>
+    </unit>
+    <unit id="uof.kelvin.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:240</note>
+      </notes>
+      <segment>
+        <source>K</source>
+      </segment>
+    </unit>
+    <unit id="uof.cm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:246</note>
+      </notes>
+      <segment>
+        <source>Cubic centimeter</source>
+      </segment>
+    </unit>
+    <unit id="uof.cm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:247</note>
+      </notes>
+      <segment>
+        <source>cm3</source>
+      </segment>
+    </unit>
+    <unit id="uof.dm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:250</note>
+      </notes>
+      <segment>
+        <source>Cubic decimeter</source>
+      </segment>
+    </unit>
+    <unit id="uof.dm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:251</note>
+      </notes>
+      <segment>
+        <source>dm3</source>
+      </segment>
+    </unit>
+    <unit id="uof.m3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:254</note>
+      </notes>
+      <segment>
+        <source>Cubic meter</source>
+      </segment>
+    </unit>
+    <unit id="uof.m3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:255</note>
+      </notes>
+      <segment>
+        <source>m3</source>
+      </segment>
+    </unit>
+    <unit id="uof.liter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:258</note>
+      </notes>
+      <segment>
+        <source>Liter</source>
+      </segment>
+    </unit>
+    <unit id="uof.liter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:259</note>
+      </notes>
+      <segment>
+        <source>L</source>
+      </segment>
+    </unit>
+    <unit id="uof.hectoliter.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:262</note>
+      </notes>
+      <segment>
+        <source>Hectoliter</source>
+      </segment>
+    </unit>
+    <unit id="uof.hectoliter.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:263</note>
+      </notes>
+      <segment>
+        <source>hL</source>
+      </segment>
+    </unit>
+    <unit id="uof.hm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:266</note>
+      </notes>
+      <segment>
+        <source>Cubic hectometer</source>
+      </segment>
+    </unit>
+    <unit id="uof.hm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:267</note>
+      </notes>
+      <segment>
+        <source>hm3</source>
+      </segment>
+    </unit>
+    <unit id="uof.m3s.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:273</note>
+      </notes>
+      <segment>
+        <source>Cubic meter per second</source>
+      </segment>
+    </unit>
+    <unit id="uof.m3s.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:274</note>
+      </notes>
+      <segment>
+        <source>m3/s</source>
+      </segment>
+    </unit>
+    <unit id="uof.Ls.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:277</note>
+      </notes>
+      <segment>
+        <source>Liter per second</source>
+      </segment>
+    </unit>
+    <unit id="uof.Ls.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:278</note>
+      </notes>
+      <segment>
+        <source>L/s</source>
+      </segment>
+    </unit>
+    <unit id="uof.m3h.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:281</note>
+      </notes>
+      <segment>
+        <source>Cubic meter per hour</source>
+      </segment>
+    </unit>
+    <unit id="uof.m3h.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:282</note>
+      </notes>
+      <segment>
+        <source>m3/h</source>
+      </segment>
+    </unit>
+    <unit id="uof.Lh.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:285</note>
+      </notes>
+      <segment>
+        <source>Liter per hour</source>
+      </segment>
+    </unit>
+    <unit id="uof.Lh.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:286</note>
+      </notes>
+      <segment>
+        <source>L/h</source>
+      </segment>
+    </unit>
+    <unit id="uof.m3d.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:289</note>
+      </notes>
+      <segment>
+        <source>Cubic meter per day</source>
+      </segment>
+    </unit>
+    <unit id="uof.m3d.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:290</note>
+      </notes>
+      <segment>
+        <source>m3/d</source>
+      </segment>
+    </unit>
+    <unit id="uof.Ld.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:293</note>
+      </notes>
+      <segment>
+        <source>Liter per day</source>
+      </segment>
+    </unit>
+    <unit id="uof.Ld.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:294</note>
+      </notes>
+      <segment>
+        <source>L/d</source>
+      </segment>
+    </unit>
+    <unit id="uof.ppm.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:300</note>
+      </notes>
+      <segment>
+        <source>Part per million</source>
+      </segment>
+    </unit>
+    <unit id="uof.ppm.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:301</note>
+      </notes>
+      <segment>
+        <source>ppm</source>
+      </segment>
+    </unit>
+    <unit id="uof.µgL.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:307</note>
+      </notes>
+      <segment>
+        <source>Microgram per liter</source>
+      </segment>
+    </unit>
+    <unit id="uof.µgL.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:308</note>
+      </notes>
+      <segment>
+        <source>µg/L</source>
+      </segment>
+    </unit>
+    <unit id="uof.mgL.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:311</note>
+      </notes>
+      <segment>
+        <source>Miligram per liter</source>
+      </segment>
+    </unit>
+    <unit id="uof.mgL.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:312</note>
+      </notes>
+      <segment>
+        <source>mg/L</source>
+      </segment>
+    </unit>
+    <unit id="uof.µgm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:315</note>
+      </notes>
+      <segment>
+        <source>Microgram per cubic meter</source>
+      </segment>
+    </unit>
+    <unit id="uof.µgm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:316</note>
+      </notes>
+      <segment>
+        <source>µ5g/m3</source>
+      </segment>
+    </unit>
+    <unit id="uof.mgm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:319</note>
+      </notes>
+      <segment>
+        <source>Milligram per cubic meter</source>
+      </segment>
+    </unit>
+    <unit id="uof.mgm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:320</note>
+      </notes>
+      <segment>
+        <source>mg/m3</source>
+      </segment>
+    </unit>
+    <unit id="uof.gL.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:323</note>
+      </notes>
+      <segment>
+        <source>Gram per liter</source>
+      </segment>
+    </unit>
+    <unit id="uof.gL.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:324</note>
+      </notes>
+      <segment>
+        <source>g/L</source>
+      </segment>
+    </unit>
+    <unit id="uof.kgm3.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:327</note>
+      </notes>
+      <segment>
+        <source>Kilogram per cubic meter</source>
+      </segment>
+    </unit>
+    <unit id="uof.kgm3.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:328</note>
+      </notes>
+      <segment>
+        <source>kg/m3</source>
+      </segment>
+    </unit>
+    <unit id="uof.byte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:334</note>
+      </notes>
+      <segment>
+        <source>Byte</source>
+      </segment>
+    </unit>
+    <unit id="uof.byte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:335</note>
+      </notes>
+      <segment>
+        <source>B</source>
+      </segment>
+    </unit>
+    <unit id="uof.kilobyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:338</note>
+      </notes>
+      <segment>
+        <source>Kilobyte</source>
+      </segment>
+    </unit>
+    <unit id="uof.kilobyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:339</note>
+      </notes>
+      <segment>
+        <source>kB</source>
+      </segment>
+    </unit>
+    <unit id="uof.megabyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:342</note>
+      </notes>
+      <segment>
+        <source>Megabyte</source>
+      </segment>
+    </unit>
+    <unit id="uof.megabyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:343</note>
+      </notes>
+      <segment>
+        <source>MB</source>
+      </segment>
+    </unit>
+    <unit id="uof.gigabyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:346</note>
+      </notes>
+      <segment>
+        <source>Gigabyte</source>
+      </segment>
+    </unit>
+    <unit id="uof.gigabyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:347</note>
+      </notes>
+      <segment>
+        <source>GB</source>
+      </segment>
+    </unit>
+    <unit id="uof.terabyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:350</note>
+      </notes>
+      <segment>
+        <source>Terabyte</source>
+      </segment>
+    </unit>
+    <unit id="uof.terabyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:351</note>
+      </notes>
+      <segment>
+        <source>TB</source>
+      </segment>
+    </unit>
+    <unit id="uof.petabyte.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:354</note>
+      </notes>
+      <segment>
+        <source>Petabyte</source>
+      </segment>
+    </unit>
+    <unit id="uof.petabyte.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:355</note>
+      </notes>
+      <segment>
+        <source>PB</source>
+      </segment>
+    </unit>
+    <unit id="uof.hertz.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:361</note>
+      </notes>
+      <segment>
+        <source>Hertz</source>
+      </segment>
+    </unit>
+    <unit id="uof.hertz.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:362</note>
+      </notes>
+      <segment>
+        <source>Hz</source>
+      </segment>
+    </unit>
+    <unit id="uof.megahertz.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:365</note>
+      </notes>
+      <segment>
+        <source>Megahertz</source>
+      </segment>
+    </unit>
+    <unit id="uof.megahertz.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:366</note>
+      </notes>
+      <segment>
+        <source>MHz</source>
+      </segment>
+    </unit>
+    <unit id="uof.gigahertz.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:369</note>
+      </notes>
+      <segment>
+        <source>Gigahertz</source>
+      </segment>
+    </unit>
+    <unit id="uof.gigahertz.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:370</note>
+      </notes>
+      <segment>
+        <source>GHz</source>
+      </segment>
+    </unit>
+    <unit id="uof.percentage.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:376</note>
+      </notes>
+      <segment>
+        <source>Percentage</source>
+      </segment>
+    </unit>
+    <unit id="uof.percentage.symbol">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:377</note>
+      </notes>
+      <segment>
+        <source>%</source>
       </segment>
     </unit>
     <unit id="8682931004646337355">

--- a/src/i18n/messages.xlf
+++ b/src/i18n/messages.xlf
@@ -2211,18 +2211,15 @@
         <source>Pa</source>
       </segment>
     </unit>
-    <unit id="uof.decibel.name">
+    <unit id="uof.db.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:161</note>
-        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:165</note>
-        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:169</note>
-        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:173</note>
       </notes>
       <segment>
         <source>Decibel</source>
       </segment>
     </unit>
-    <unit id="uof.decibel.symbol">
+    <unit id="uof.db.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:162</note>
       </notes>
@@ -2230,7 +2227,15 @@
         <source>db</source>
       </segment>
     </unit>
-    <unit id="uof.decibela.symbol">
+    <unit id="uof.dba.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:165</note>
+      </notes>
+      <segment>
+        <source>Decibel</source>
+      </segment>
+    </unit>
+    <unit id="uof.dba.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:166</note>
       </notes>
@@ -2238,7 +2243,15 @@
         <source>db(A)</source>
       </segment>
     </unit>
-    <unit id="uof.decibelb.symbol">
+    <unit id="uof.dbb.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:169</note>
+      </notes>
+      <segment>
+        <source>Decibel</source>
+      </segment>
+    </unit>
+    <unit id="uof.dbb.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:170</note>
       </notes>
@@ -2246,7 +2259,15 @@
         <source>db(B)</source>
       </segment>
     </unit>
-    <unit id="uof.decibelc.symbol">
+    <unit id="uof.dbc.name">
+      <notes>
+        <note category="location">src/app/model/bodies/unitOfMeasurements.ts:173</note>
+      </notes>
+      <segment>
+        <source>Decibel</source>
+      </segment>
+    </unit>
+    <unit id="uof.dbc.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:174</note>
       </notes>
@@ -2270,7 +2291,7 @@
         <source>W</source>
       </segment>
     </unit>
-    <unit id="uof.kilowatt.name">
+    <unit id="uof.kw.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:181</note>
       </notes>
@@ -2278,7 +2299,7 @@
         <source>Kilowatt</source>
       </segment>
     </unit>
-    <unit id="uof.kilowatt.symbol">
+    <unit id="uof.kw.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:182</note>
       </notes>
@@ -2286,7 +2307,7 @@
         <source>kW</source>
       </segment>
     </unit>
-    <unit id="uof.megawatt.name">
+    <unit id="uof.mw.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:185</note>
       </notes>
@@ -2294,7 +2315,7 @@
         <source>Megawatt</source>
       </segment>
     </unit>
-    <unit id="uof.megawatt.symbol">
+    <unit id="uof.mw.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:186</note>
       </notes>
@@ -2302,7 +2323,7 @@
         <source>MW</source>
       </segment>
     </unit>
-    <unit id="uof.gigawatt.name">
+    <unit id="uof.gw.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:189</note>
       </notes>
@@ -2310,7 +2331,7 @@
         <source>Gigawatt</source>
       </segment>
     </unit>
-    <unit id="uof.gigawatt.symbol">
+    <unit id="uof.gw.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:190</note>
       </notes>
@@ -2334,7 +2355,7 @@
         <source>kVA</source>
       </segment>
     </unit>
-    <unit id="uof.kA.name">
+    <unit id="uof.ka.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:197</note>
       </notes>
@@ -2342,7 +2363,7 @@
         <source>Ampère</source>
       </segment>
     </unit>
-    <unit id="uof.kA.symbol">
+    <unit id="uof.ka.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:198</note>
       </notes>
@@ -2366,7 +2387,7 @@
         <source>V</source>
       </segment>
     </unit>
-    <unit id="uof.kilovolt.name">
+    <unit id="uof.kv.name">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:205</note>
       </notes>
@@ -2374,7 +2395,7 @@
         <source>Kilovolt</source>
       </segment>
     </unit>
-    <unit id="uof.kilovolt.symbol">
+    <unit id="uof.kv.symbol">
       <notes>
         <note category="location">src/app/model/bodies/unitOfMeasurements.ts:206</note>
       </notes>


### PR DESCRIPTION
Added a unit-of-measurement component to datastreams, where the measurement-unit name, and symbol van be inserted. Suggestions are provided based on default unit-of-measurements provided in the excel in issue #196. Suggestions are provided via typeahead, where both fields are filled when a suggestion is selected. The suggestions are shown in the user's language.

![unit-of-measurement](https://user-images.githubusercontent.com/53855759/147148182-80219e6d-0ec0-4b41-9e7a-cd3f9db84412.png)

closes #196
