### PR TITLE
Fix sensor type validation UI

### DIFF
--- a/src/app/form-controls/sensor/sensor.component.html
+++ b/src/app/form-controls/sensor/sensor.component.html
@@ -6,26 +6,28 @@
     <div formArrayName="sensors" *ngFor="let sensor of parentForm.get('sensors')['controls']; let i = index;" class="col-6 mt-3 form-group">
         <div class="row py-3 bg-light border rounded" formGroupName="{{i}}">
             <div class="col-12">
-                <label i18n>Name</label>
                 <button (click)="removeSensor(i)" type="button" class="close float-right" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
-                <input formControlName="name" type="text" placeholder="Sensor name" class="form-control" i18n-placeholder>
+                <label i18n>Name</label>
+                <input formControlName="name" type="text" placeholder="Sensor name" class="form-control" i18n-placeholder
+                    [ngClass]="{ 'is-invalid': (getSensorElement(i, 'name').dirty || getSensorElement(i, 'name').touched || submitted) && getSensorElement(i, 'name').errors }"
+                >
                 <div *ngIf="(getSensorElement(i, 'name').dirty || getSensorElement(i, 'name').touched || submitted) && getSensorElement(i, 'name').errors" class="invalid-input">
                     <span class="required-text" *ngIf="getSensorElement(i, 'name').errors.required" i18n>Name is required</span>
                 </div>
             </div>
             <div class="col-12">
                 <label i18n>Description</label>
-                <input class="form-control" type="text" formControlName="description" placeholder="Describe the sensor"
-                       [ngClass]="{ 'is-invalid': (getSensorElement(i, 'description').dirty || getSensorElement(i, 'description').touched || submitted) && getSensorElement(i, 'description').errors }"
-                       i18n-placeholder>
+                <input formControlName="description" type="text" placeholder="Describe the sensor" class="form-control" i18n-placeholder
+                    [ngClass]="{ 'is-invalid': (getSensorElement(i, 'description').dirty || getSensorElement(i, 'description').touched || submitted) && getSensorElement(i, 'description').errors }"
+                >
                 <div *ngIf="(getSensorElement(i, 'description').dirty || getSensorElement(i, 'description').touched || submitted) && getSensorElement(i, 'description').errors" class="invalid-input">
                     <span class="required-text" *ngIf="getSensorElement(i, 'description').errors.required" i18n>Description is required</span>
                 </div>
             </div>
             <div class="col-12">
-                <app-sensor-type formControlName="typeName" [submitted]="submitted"></app-sensor-type>
+                <app-sensor-type formControlName="typeName" [sensorIdx]="i" [submitted]="submitted"></app-sensor-type>
             </div>
             <div class="col-12">
                 <label><span i18n>Manufacturer</span><span class="font-italic text-muted" i18n> - Optional</span></label>

--- a/src/app/form-controls/type/type.component.html
+++ b/src/app/form-controls/type/type.component.html
@@ -1,6 +1,6 @@
 <div [formGroup]="form" class="form-group">
     <label for="type"><span i18n>Type</span></label>
-    <select formControlName="value" class="form-control selectpicker" title="Nothing selected" data-live-search="true" i18n-title>
+    <select formControlName="typeName" class="form-control selectpicker" title="Nothing selected" data-live-search="true" i18n-title>
         <ng-container *ngFor="let sensorType of sensorTypes">
             <option class="font-weight-bold" [value]="sensorType.key">
                 {{ sensorType.value }}
@@ -10,7 +10,7 @@
             </option>
         </ng-container>
     </select>
-    <div *ngIf="(f.value.dirty || f.value.touched || submitted) && f.value.errors" class="invalid-input">
-        <span class="required-text" *ngIf="f.value.errors.required" i18n>Type is required</span>
+    <div *ngIf="(f.typeName.dirty || f.typeName.touched || submitted) && f.typeName.errors" class="invalid-input">
+        <span class="required-text" *ngIf="f.typeName.errors.required" i18n>Type is required</span>
     </div>
 </div>

--- a/src/app/form-controls/type/type.component.ts
+++ b/src/app/form-controls/type/type.component.ts
@@ -50,8 +50,7 @@ export class TypeComponent implements ControlValueAccessor, OnInit, OnDestroy, A
 
     public sensorTypes = getSensorTypesTranslation(this.locale);
 
-    constructor(private rootFormGroup: FormGroupDirective, @Inject(LOCALE_ID) private locale: string) {
-    }
+    constructor(private rootFormGroup: FormGroupDirective, @Inject(LOCALE_ID) private locale: string) {}
 
     public get f() {
         return this.form.controls;
@@ -95,7 +94,7 @@ export class TypeComponent implements ControlValueAccessor, OnInit, OnDestroy, A
 
     ngOnInit(): void {
         this.form = this.rootFormGroup.control.get(`sensors.${this.sensorIdx}`) as FormGroup;
-        
+
         this.subscriptions.push(
             // any time the inner form changes update the parent of any change
             this.form.valueChanges.subscribe((value) => {
@@ -103,7 +102,7 @@ export class TypeComponent implements ControlValueAccessor, OnInit, OnDestroy, A
                 this.onTouched();
             }),
         );
-        
+
         ($('.selectpicker') as any).selectpicker('refresh');
     }
 }

--- a/src/app/form-controls/type/type.component.ts
+++ b/src/app/form-controls/type/type.component.ts
@@ -85,7 +85,7 @@ export class TypeComponent implements ControlValueAccessor, OnInit, OnDestroy, A
 
     // communicate the inner form validation to the parent form
     public validate(_: FormControl) {
-        return this.form.valid ? null : { typeName: { valid: false } };
+        return this.form.controls.typeName.valid;
     }
 
     ngAfterViewInit(): void {
@@ -94,15 +94,6 @@ export class TypeComponent implements ControlValueAccessor, OnInit, OnDestroy, A
 
     ngOnInit(): void {
         this.form = this.rootFormGroup.control.get(`sensors.${this.sensorIdx}`) as FormGroup;
-
-        this.subscriptions.push(
-            // any time the inner form changes update the parent of any change
-            this.form.valueChanges.subscribe((value) => {
-                this.onChange(value.typeName);
-                this.onTouched();
-            }),
-        );
-
         ($('.selectpicker') as any).selectpicker('refresh');
     }
 }

--- a/src/app/form-controls/type/type.component.ts
+++ b/src/app/form-controls/type/type.component.ts
@@ -2,9 +2,9 @@ import { Component, forwardRef, OnDestroy, Input, AfterViewInit, OnInit, Inject,
 
 import {
     ControlValueAccessor,
-    FormBuilder,
     FormControl,
     FormGroup,
+    FormGroupDirective,
     NG_VALIDATORS,
     NG_VALUE_ACCESSOR,
 } from '@angular/forms';
@@ -32,6 +32,7 @@ export class TypeComponent implements ControlValueAccessor, OnInit, OnDestroy, A
     public form: FormGroup;
     public subscriptions: Subscription[] = [];
 
+    @Input() public sensorIdx: number;
     @Input() public submitted: boolean;
 
     get value() {
@@ -49,18 +50,7 @@ export class TypeComponent implements ControlValueAccessor, OnInit, OnDestroy, A
 
     public sensorTypes = getSensorTypesTranslation(this.locale);
 
-    constructor(private formBuilder: FormBuilder, @Inject(LOCALE_ID) private locale: string) {
-        this.form = this.formBuilder.group({
-            value: new FormControl([]),
-        });
-
-        this.subscriptions.push(
-            // any time the inner form changes update the parent of any change
-            this.form.valueChanges.subscribe((value) => {
-                this.onChange(value);
-                this.onTouched();
-            }),
-        );
+    constructor(private rootFormGroup: FormGroupDirective, @Inject(LOCALE_ID) private locale: string) {
     }
 
     public get f() {
@@ -96,7 +86,7 @@ export class TypeComponent implements ControlValueAccessor, OnInit, OnDestroy, A
 
     // communicate the inner form validation to the parent form
     public validate(_: FormControl) {
-        return this.form.valid ? null : { theme: { valid: false } };
+        return this.form.valid ? null : { typeName: { valid: false } };
     }
 
     ngAfterViewInit(): void {
@@ -104,6 +94,16 @@ export class TypeComponent implements ControlValueAccessor, OnInit, OnDestroy, A
     }
 
     ngOnInit(): void {
+        this.form = this.rootFormGroup.control.get(`sensors.${this.sensorIdx}`) as FormGroup;
+        
+        this.subscriptions.push(
+            // any time the inner form changes update the parent of any change
+            this.form.valueChanges.subscribe((value) => {
+                this.onChange(value.typeName);
+                this.onTouched();
+            }),
+        );
+        
         ($('.selectpicker') as any).selectpicker('refresh');
     }
 }

--- a/src/app/forms/device/device.component.ts
+++ b/src/app/forms/device/device.component.ts
@@ -239,7 +239,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
                     id: sensor._id,
                     name: [sensor.name, Validators.required],
                     description: [sensor.description, Validators.required],
-                    typeName: [sensor.type ? { value: sensor.type } : null, Validators.required],
+                    typeName: [sensor.type, Validators.required],
                     manufacturer: sensor.manufacturer,
                     supplier: sensor.supplier,
                     documentation: [sensor.documentation, [Validators.pattern(urlRegex)]],
@@ -366,7 +366,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
                 const sensor: IRegisterSensorBody = {
                     name: sensorEntryValue.name,
                     description: sensorEntryValue.description,
-                    type: sensorEntryValue.typeName.value,
+                    type: sensorEntryValue.typeName,
                     manufacturer: sensorEntryValue.manufacturer,
                     supplier: sensorEntryValue.supplier,
                     documentation: sensorEntryValue.documentation,
@@ -390,7 +390,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
                     sensorUpdate.description = sensorEntryValue.description;
                 }
                 if (sensorEntry.get('typeName').dirty) {
-                    sensorUpdate.type = sensorEntryValue.typeName.value;
+                    sensorUpdate.type = sensorEntryValue.typeName;
                 }
                 if (sensorEntry.get('manufacturer').dirty) {
                     sensorUpdate.manufacturer = sensorEntryValue.manufacturer;


### PR DESCRIPTION
Type krijgt nu correct een error bericht. Bootstrap ondersteund ook een `is-invalid` klasse op `select`s, maar helaas wordt dit niet ondersteund door de `bootstrap-select` plugin die we gebruiken.

Oplichten van het Naam veld is ook gefixt.

Eerst:
![image](https://user-images.githubusercontent.com/56066664/149151343-4d872f01-6bdf-4b50-ac71-7c914f0a9781.png)

Nu:
![image](https://user-images.githubusercontent.com/56066664/149151253-72dc5919-dd70-4f4a-98c7-6c6c207a80f4.png)
