### PR TITLE
Prevent multiple identical devices

### DIFF
--- a/src/app/forms/device/device.component.html
+++ b/src/app/forms/device/device.component.html
@@ -16,7 +16,7 @@
                 </div>
             </div>
             <hr>
-            <form [formGroup]="deviceForm" (ngSubmit)="submitDevice()">
+            <form [formGroup]="deviceForm" (ngSubmit)="submitDevice()" *ngIf="!deviceLoading">
                 <div [ngStyle]="{display: activeStepIndex === 0 ? 'block' : 'none'}">
                     <div *ngIf="deviceControls.id.value" class="form-group">
                         <span i18n>ID:</span>
@@ -72,6 +72,9 @@
                     <button type="button" class="btn btn-outline-secondary btn-lg" (click)="goToStep(activeStepIndex - 1)" i18n>Previous</button>
                 </div>
             </form>
+            <div *ngIf="deviceLoading" class="spinner-border" role="status">
+                <span class="sr-only" i18n>Loading...</span>
+            </div>
         </div>
         <div *ngIf="activeStepIndex === 0 || activeStepIndex === 2" class="col-5" style="height: 85vh; max-height: 85vh">
             <app-map searchBarHeight="1.5rem" [clearLocationHighLight]="!deviceId"></app-map>

--- a/src/app/forms/device/device.component.ts
+++ b/src/app/forms/device/device.component.ts
@@ -33,6 +33,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
 
     public subscriptions: Subscription[] = [];
 
+    private submitting = false;
     public deviceForm: FormGroup;
     public sensorForm: FormGroup;
 
@@ -254,7 +255,12 @@ export class DeviceComponent implements OnInit, OnDestroy {
         if (this.deviceForm.value.id) {
             await this.updateDevice();
         } else {
+            if (this.submitting) {
+                return;
+            }
+            this.submitting = true;
             await this.createDevice();
+            this.submitting = false;
         }
     }
 

--- a/src/app/forms/device/device.component.ts
+++ b/src/app/forms/device/device.component.ts
@@ -49,7 +49,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
     public saveFailedMessage = $localize`:@@device.register.failure:An error has occurred during saving:`;
 
     public deviceLoading = false;
-    private deviceCreated$: Observable<IDevice>;
+    private deviceLocated$: Observable<IDevice>;
 
     constructor(
         private readonly route: ActivatedRoute,
@@ -622,12 +622,14 @@ export class DeviceComponent implements OnInit, OnDestroy {
             // registering a device, both DeviceRegistered and DeviceLocated are created, the latter being the last to
             // be created. Waiting for DeviceRegistered might therefore trigger the resolve while not all information is
             // available.
-            this.deviceCreated$ = this.connectionService.subscribeTo(EventType.DeviceLocated);
-            this.deviceCreated$.subscribe((device: IDevice) => {
+            this.deviceLocated$ = this.connectionService.subscribeTo(EventType.DeviceLocated);
+            const onDeviceLocated = (device: IDevice) => {
                 if (device._id === deviceId) {
                     resolve(device);
                 }
-            });
+            };
+            const deviceLocatedSubscription = this.deviceLocated$.subscribe(onDeviceLocated);
+            this.subscriptions.push(deviceLocatedSubscription);
         });
     }
 

--- a/src/app/forms/device/device.component.ts
+++ b/src/app/forms/device/device.component.ts
@@ -16,6 +16,7 @@ import {
     IRegisterSensorBody,
     IUpdateDatastreamBody,
     IUpdateDeviceBody,
+    IUpdateLocationBody,
     IUpdateSensorBody,
 } from '../../services/device.service';
 import { LocationService } from '../../services/location.service';
@@ -274,7 +275,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
     }
 
     private async updateDevice() {
-        const deviceUpdate: Record<string, any> = {};
+        const deviceUpdate: IUpdateDeviceBody = {};
         if (this.deviceForm.controls.name.dirty) {
             deviceUpdate.name = this.deviceForm.value.name;
         }
@@ -287,7 +288,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
         if (this.deviceForm.controls.connectivity.dirty) {
             deviceUpdate.connectivity = this.deviceForm.value.connectivity;
         }
-        const location: Record<string, any> = {};
+        const location: IUpdateLocationBody = {};
         if (this.deviceForm.controls.locationName.dirty) {
             location.name = this.deviceForm.value.locationName;
         }
@@ -304,9 +305,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
 
         try {
             if (Object.keys(deviceUpdate).length) {
-                await this.deviceService
-                    .update(this.deviceForm.value.id, deviceUpdate as IUpdateDeviceBody)
-                    .toPromise();
+                await this.deviceService.update(this.deviceForm.value.id, deviceUpdate).toPromise();
                 this.deviceForm.markAsPristine();
                 this.alertService.success(this.saveSuccessMessage);
             }
@@ -405,7 +404,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
                     this.alertService.error(e.error.message);
                 }
             } else {
-                const sensorUpdate: Record<string, any> = {};
+                const sensorUpdate: IUpdateSensorBody = {};
                 if (sensorEntry.get('name').dirty) {
                     sensorUpdate.name = sensorEntryValue.name;
                 }
@@ -428,7 +427,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
                 try {
                     if (Object.keys(sensorUpdate).length) {
                         await this.deviceService
-                            .updateSensor(this.deviceId, sensorEntryValue.id, sensorUpdate as IUpdateSensorBody)
+                            .updateSensor(this.deviceId, sensorEntryValue.id, sensorUpdate)
                             .toPromise();
                         this.alertService.success(this.saveSuccessMessage);
                     }
@@ -479,7 +478,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
             'unitOfMeasurement',
         ];
 
-        const datastreamUpdate: Record<string, any> = {};
+        const datastreamUpdate: IUpdateDatastreamBody = {};
         if (datastreamFormEntry.get('theme').dirty) {
             datastreamUpdate.theme = datastreamFormValue.theme ? datastreamFormValue.theme.value : null;
         }
@@ -495,7 +494,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
 
         if (Object.keys(datastreamUpdate).length) {
             await this.deviceService
-                .updateDatastream(this.deviceId, sensorId, datastreamId, datastreamUpdate as IUpdateDatastreamBody)
+                .updateDatastream(this.deviceId, sensorId, datastreamId, datastreamUpdate)
                 .toPromise();
         }
     }

--- a/src/app/forms/device/device.component.ts
+++ b/src/app/forms/device/device.component.ts
@@ -252,74 +252,82 @@ export class DeviceComponent implements OnInit, OnDestroy {
 
     public async saveDevice() {
         if (this.deviceForm.value.id) {
-            const deviceUpdate: Record<string, any> = {};
-            if (this.deviceForm.controls.name.dirty) {
-                deviceUpdate.name = this.deviceForm.value.name;
-            }
-            if (this.deviceForm.controls.description.dirty) {
-                deviceUpdate.description = this.deviceForm.value.description;
-            }
-            if (this.deviceForm.controls.category.dirty) {
-                deviceUpdate.category = this.deviceForm.value.category.category;
-            }
-            if (this.deviceForm.controls.connectivity.dirty) {
-                deviceUpdate.connectivity = this.deviceForm.value.connectivity;
-            }
-            const location: Record<string, any> = {};
-            if (this.deviceForm.controls.locationName.dirty) {
-                location.name = this.deviceForm.value.locationName;
-            }
-            if (this.deviceForm.controls.locationDescription.dirty) {
-                location.description = this.deviceForm.value.locationDescription;
-            }
-            if (this.deviceForm.controls.location.dirty) {
-                const deviceLocation = this.deviceForm.value.location;
-                location.location = [deviceLocation.longitude, deviceLocation.latitude, deviceLocation.height];
-            }
-            if (Object.keys(location).length) {
-                deviceUpdate.location = location;
-            }
-
-            try {
-                if (Object.keys(deviceUpdate).length) {
-                    await this.deviceService
-                        .update(this.deviceForm.value.id, deviceUpdate as IUpdateDeviceBody)
-                        .toPromise();
-                    this.deviceForm.markAsPristine();
-                    this.alertService.success(this.saveSuccessMessage);
-                }
-            } catch (e) {
-                this.alertService.error(e.error.message);
-            }
-
-            this.submitted = false;
+            await this.updateDevice();
         } else {
+            await this.createDevice();
+        }
+    }
+
+    private async updateDevice() {
+        const deviceUpdate: Record<string, any> = {};
+        if (this.deviceForm.controls.name.dirty) {
+            deviceUpdate.name = this.deviceForm.value.name;
+        }
+        if (this.deviceForm.controls.description.dirty) {
+            deviceUpdate.description = this.deviceForm.value.description;
+        }
+        if (this.deviceForm.controls.category.dirty) {
+            deviceUpdate.category = this.deviceForm.value.category.category;
+        }
+        if (this.deviceForm.controls.connectivity.dirty) {
+            deviceUpdate.connectivity = this.deviceForm.value.connectivity;
+        }
+        const location: Record<string, any> = {};
+        if (this.deviceForm.controls.locationName.dirty) {
+            location.name = this.deviceForm.value.locationName;
+        }
+        if (this.deviceForm.controls.locationDescription.dirty) {
+            location.description = this.deviceForm.value.locationDescription;
+        }
+        if (this.deviceForm.controls.location.dirty) {
             const deviceLocation = this.deviceForm.value.location;
-            const device: IRegisterDeviceBody = {
-                name: this.deviceForm.value.name,
-                description: this.deviceForm.value.description,
-                category: this.deviceForm.value.category.category,
-                connectivity: this.deviceForm.value.connectivity,
-                location: {
-                    name: this.deviceForm.value.locationName,
-                    description: this.deviceForm.value.locationDescription,
-                    location: deviceLocation
-                        ? [deviceLocation.longitude, deviceLocation.latitude, deviceLocation.height]
-                        : null,
-                },
-            };
+            location.location = [deviceLocation.longitude, deviceLocation.latitude, deviceLocation.height];
+        }
+        if (Object.keys(location).length) {
+            deviceUpdate.location = location;
+        }
 
-            try {
-                const deviceDetails: Record<string, any> = await this.deviceService.register(device).toPromise();
-                this.deviceId = deviceDetails.deviceId;
+        try {
+            if (Object.keys(deviceUpdate).length) {
+                await this.deviceService
+                    .update(this.deviceForm.value.id, deviceUpdate as IUpdateDeviceBody)
+                    .toPromise();
                 this.deviceForm.markAsPristine();
-
-                this.locationService.showLocation(null);
                 this.alertService.success(this.saveSuccessMessage);
-                this.submitted = false;
-            } catch (e) {
-                this.alertService.error(`${this.saveFailedMessage} ${e.error.message}.`);
             }
+        } catch (e) {
+            this.alertService.error(e.error.message);
+        }
+
+        this.submitted = false;
+    }
+
+    private async createDevice() {
+        const deviceLocation = this.deviceForm.value.location;
+        const device: IRegisterDeviceBody = {
+            name: this.deviceForm.value.name,
+            description: this.deviceForm.value.description,
+            category: this.deviceForm.value.category.category,
+            connectivity: this.deviceForm.value.connectivity,
+            location: {
+                name: this.deviceForm.value.locationName,
+                description: this.deviceForm.value.locationDescription,
+                location: deviceLocation
+                    ? [deviceLocation.longitude, deviceLocation.latitude, deviceLocation.height]
+                    : null,
+            },
+        };
+
+        try {
+            const deviceDetails: Record<string, any> = await this.deviceService.register(device).toPromise();
+            this.deviceId = deviceDetails.deviceId;
+            this.deviceForm.markAsPristine();
+
+            this.locationService.showLocation(null);
+            this.alertService.success(this.saveSuccessMessage);
+            this.submitted = false;
+        } catch (e) {
+            this.alertService.error(`${this.saveFailedMessage} ${e.error.message}.`);
         }
     }
 

--- a/src/app/forms/device/device.component.ts
+++ b/src/app/forms/device/device.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { urlRegex } from '../../helpers/form.helpers';
 import { IDevice } from '../../model/bodies/device-model';
@@ -46,6 +46,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
 
     constructor(
         private readonly route: ActivatedRoute,
+        private readonly router: Router,
         private readonly formBuilder: FormBuilder,
         private readonly alertService: AlertService,
         private readonly deviceService: DeviceService,
@@ -261,6 +262,7 @@ export class DeviceComponent implements OnInit, OnDestroy {
             this.submitting = true;
             await this.createDevice();
             this.submitting = false;
+            await this.router.navigate([`/device/${this.deviceId}`]);
         }
     }
 


### PR DESCRIPTION
Prevent the creation of multiple devices from the same form.
- Send device form once when clicking Submit button multiple times
- Go to edit mode after device has been registered
  - Listen on websocket in case the CQRS have not yet been updated

Below an example of loading of device page. In the example the back-end the events are created normally, but has been tweaked to take multiple seconds to update the Mongo projection.

![feature](https://user-images.githubusercontent.com/56066664/149813318-2611a75b-ce2e-4ce4-a74d-04a29bc1b362.gif)

Closes https://github.com/kadaster-labs/sensrnet-registry-frontend/issues/195