### PR TITLE
fix: no longer set name based on device category

### DIFF
--- a/src/app/form-controls/device-type/device-type.component.ts
+++ b/src/app/form-controls/device-type/device-type.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, OnDestroy, Input, EventEmitter, Output } from '@angular/core';
+import { Component, forwardRef, OnDestroy, Input } from '@angular/core';
 import {
     NG_VALUE_ACCESSOR,
     NG_VALIDATORS,
@@ -37,7 +37,6 @@ export class DeviceTypeComponent implements ControlValueAccessor, OnDestroy {
     public subscriptions: Subscription[] = [];
 
     @Input() public submitted: boolean;
-    @Output() sensorType = new EventEmitter<string>();
 
     public sensorCategories = Category;
     public getCategoryTranslation = getCategoryTranslation;
@@ -66,24 +65,10 @@ export class DeviceTypeComponent implements ControlValueAccessor, OnDestroy {
                 this.onTouched();
             }),
         );
-
-        this.onFormChanges();
     }
 
     get f() {
         return this.form.controls;
-    }
-
-    private onFormChanges() {
-        if (!this.form.get('category')) {
-            return;
-        }
-
-        this.form.get('category').valueChanges.subscribe((category: Category) => {
-            if (category) {
-                this.sensorType.emit(category);
-            }
-        });
     }
 
     public ngOnDestroy() {

--- a/src/app/forms/device/device.component.html
+++ b/src/app/forms/device/device.component.html
@@ -22,7 +22,7 @@
                         <span i18n>ID:</span>
                         <span class="font-weight-bold ml-1">{{ deviceControls.id.value }}</span>
                     </div>
-                    <app-device-type formControlName="category" [submitted]="submitted" (sensorType)="setNameFromCategory($event)"></app-device-type>
+                    <app-device-type formControlName="category" [submitted]="submitted"></app-device-type>
                     <div class="form-group">
                         <label i18n>Name</label>
                         <input class="form-control" type="text" formControlName="name" placeholder="Enter name"

--- a/src/app/forms/device/device.component.ts
+++ b/src/app/forms/device/device.component.ts
@@ -5,7 +5,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Observable, Subscription } from 'rxjs';
 import { urlRegex } from '../../helpers/form.helpers';
 import { IDevice } from '../../model/bodies/device-model';
-import { getCategoryTranslation } from '../../model/bodies/sensorTypes';
 import { EventType } from '../../model/events/event-type';
 import { AlertService } from '../../services/alert.service';
 import { ConnectionService } from '../../services/connection.service';
@@ -65,10 +64,6 @@ export class DeviceComponent implements OnInit, OnDestroy {
 
     get deviceControls() {
         return this.deviceForm.controls;
-    }
-
-    public setNameFromCategory(item: string) {
-        this.deviceForm.controls.name.setValue(getCategoryTranslation(item));
     }
 
     public async goToStep(step: number): Promise<void> {


### PR DESCRIPTION
Disabled "generating" device name.

Name was automatically set once the device category was chosen. This led to problems as the Angular form was preloaded for existing devices. For now, just disable this functionality, we don't want users to use the default name anyway. Furthermore, some of the default names (i.e. "baken") are too short and fail the validation. The users then needs to correct the generated input, limiting the usefulness of the feature.

Closes https://github.com/kadaster-labs/sensrnet-registry-frontend/issues/212